### PR TITLE
fix: Improve Dockerfile build reliability with timeout and retry settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,54 @@ RUN apt-get update && apt-get install -y \
 # Copy requirements first for better caching
 COPY config/requirements.txt .
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+# Upgrade pip first
+RUN pip install --upgrade pip setuptools wheel
+
+# Install Python dependencies with increased timeout and retries
+# Split into two steps: core dependencies first, then paper-qa
+RUN pip install --no-cache-dir --default-timeout=300 --retries=5 \
+    torch>=2.1.0+cpu \
+    torchvision>=0.16.0+cpu \
+    torchaudio>=2.1.0+cpu \
+    --extra-index-url https://download.pytorch.org/whl/cpu \
+    transformers>=4.34.0 \
+    scikit-learn>=1.3.0 \
+    pandas>=2.1.1 \
+    numpy>=1.26.0 \
+    biopython>=1.81 \
+    sentencepiece>=0.1.99 \
+    accelerate>=0.24.0 \
+    datasets>=2.14.0 \
+    google-generativeai>=0.7.2 \
+    tiktoken>=0.5.0 \
+    requests>=2.31.0 \
+    beautifulsoup4>=4.12.2 \
+    lxml>=4.9.0 \
+    openpyxl>=3.1.0 \
+    xlrd>=2.0.1 \
+    tqdm>=4.65.0 \
+    python-dotenv>=1.0.0 \
+    fastapi>=0.104.0 \
+    "uvicorn[standard]>=0.23.2" \
+    aiohttp>=3.8.6 \
+    websockets>=11.0.3 \
+    python-multipart>=0.0.5 \
+    aiofiles>=0.7.0 \
+    pydantic>=2.4.2 \
+    typing-extensions>=3.10.0.2 \
+    starlette>=0.31.1 \
+    click>=8.0.1 \
+    h11>=0.12.0 \
+    httptools>=0.3.0 \
+    PyYAML>=5.4.1 \
+    "watchfiles[watchdog]>=1.0.0" \
+    wsproto>=1.0.0 \
+    tokenizers>=0.14.1 \
+    pytz>=2023.3
+
+# Install paper-qa from PyPI (no local directory needed)
+# The code imports from 'paperqa' package, which works with standard pip install
+RUN pip install --no-cache-dir --default-timeout=300 --retries=5 paper-qa>=5.0.0
 
 # Copy application code
 COPY . .


### PR DESCRIPTION

- Upgrade pip, setuptools, and wheel before installing dependencies
- Add increased timeout (300s) and retry logic (5 retries) for pip installs
- Split dependency installation into steps for better error handling
- Install paper-qa from PyPI (no local directory dependency needed)
- Addresses network timeout issues during Docker builds

This fixes the 'Read timed out' errors that occurred when downloading large packages like pandas, torch, etc. during Docker builds.