### PR TITLE
Fix test import issues for Docker container environment

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,0 +1,76 @@
+# Testing Guide - Running Tests
+
+## Quick Start: Run a Single Test File
+
+### Option 1: Using Docker (Recommended)
+
+If your container is already running:
+
+```bash
+# Run the specific test file
+docker exec bioanalyzer-api pytest tests/test_pubmed_retriever_errors.py -v
+
+# Run with more detailed output
+docker exec bioanalyzer-api pytest tests/test_pubmed_retriever_errors.py -v -s
+
+# Run a specific test function
+docker exec bioanalyzer-api pytest tests/test_pubmed_retriever_errors.py::test_fetch_paper_metadata_handles_no_response -v
+```
+
+### Option 2: Using the Test Script
+
+```bash
+# Make sure the script is executable
+chmod +x run_tests.sh
+
+# Run the specific test file
+./run_tests.sh tests/test_pubmed_retriever_errors.py
+```
+
+### Option 3: If Container is Not Running
+
+```bash
+# Start the container first
+BioAnalyzer start
+
+# Then run the test
+docker exec bioanalyzer-api pytest tests/test_pubmed_retriever_errors.py -v
+```
+
+## Understanding Test Output
+
+### Passing Test
+```
+tests/test_pubmed_retriever_errors.py::test_fetch_paper_metadata_handles_no_response PASSED
+```
+
+### Failing Test
+```
+tests/test_pubmed_retriever_errors.py::test_fetch_paper_metadata_handles_no_response FAILED
+[Error details will be shown]
+```
+
+## Useful pytest Flags
+
+- `-v` or `--verbose`: Show detailed output
+- `-s`: Show print statements (useful for debugging)
+- `-x`: Stop on first failure
+- `--tb=short`: Shorter traceback format
+- `-k "pattern"`: Run tests matching a pattern
+
+## Example Commands
+
+```bash
+# Run with verbose output and show print statements
+docker exec bioanalyzer-api pytest tests/test_pubmed_retriever_errors.py -v -s
+
+# Run and stop on first failure
+docker exec bioanalyzer-api pytest tests/test_pubmed_retriever_errors.py -v -x
+
+# Run all tests in the tests directory
+docker exec bioanalyzer-api pytest tests/ -v
+
+# Run tests matching a pattern
+docker exec bioanalyzer-api pytest tests/ -v -k "pubmed"
+```
+

--- a/tests/_setup_path.py
+++ b/tests/_setup_path.py
@@ -5,6 +5,10 @@ This must be imported before any app.* imports in test files.
 import sys
 from pathlib import Path
 
+# Add /app/app to path FIRST (Docker has nested structure: /app/app/services/)
+if '/app/app' not in sys.path:
+    sys.path.insert(0, '/app/app')
+
 # Add /app to path (for Docker containers)
 if '/app' not in sys.path:
     sys.path.insert(0, '/app')

--- a/tests/test_pubmed_retriever_errors.py
+++ b/tests/test_pubmed_retriever_errors.py
@@ -1,11 +1,32 @@
-from app.services.data_retrieval import PubMedRetriever
-
-
 def test_fetch_paper_metadata_handles_no_response(monkeypatch):
     """
     fetch_paper_metadata should return a structured error when the
     underlying _make_request returns no data (e.g., network failure).
     """
+    # CRITICAL: Set up path INSIDE test function - pytest may reset it
+    import sys
+    import importlib.util
+    
+    # Ensure /app/app is first (where the actual app package is)
+    if '/app/app' not in sys.path:
+        sys.path.insert(0, '/app/app')
+    # Also add /app (parent directory)
+    if '/app' not in sys.path:
+        sys.path.insert(0, '/app')
+    
+    # Try direct import first
+    try:
+        from app.services.data_retrieval import PubMedRetriever
+    except ImportError:
+        # Fallback: use importlib to load directly from file
+        spec = importlib.util.spec_from_file_location(
+            "data_retrieval",
+            "/app/app/services/data_retrieval.py"
+        )
+        data_retrieval_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(data_retrieval_module)
+        PubMedRetriever = data_retrieval_module.PubMedRetriever
+    
     retriever = PubMedRetriever(api_key=None)
 
     def _fake_make_request(endpoint, params, retries=None):
@@ -17,5 +38,3 @@ def test_fetch_paper_metadata_handles_no_response(monkeypatch):
     assert isinstance(result, dict)
     assert "error" in result
     assert "PubMed unreachable" in result["error"]
-
-


### PR DESCRIPTION
- Fix ModuleNotFoundError in test_pubmed_retriever_errors.py
- Add importlib fallback for loading modules when standard import fails
- Update _setup_path.py to handle nested /app/app directory structure
- Add TESTING_GUIDE.md with instructions for running tests
- Test now successfully runs in Docker container with proper path setup

The test was failing because pytest wasn't respecting PYTHONPATH in Docker. Solution uses importlib as fallback to directly load modules from file path.