### PR TITLE
Extraction prompt

### DIFF
--- a/app/normalization/__init__.py
+++ b/app/normalization/__init__.py
@@ -1,2 +1,1 @@
 """Normalization helpers for curator-desk aligned outputs."""
-

--- a/app/normalization/__init__.py
+++ b/app/normalization/__init__.py
@@ -1,0 +1,2 @@
+"""Normalization helpers for curator-desk aligned outputs."""
+

--- a/app/normalization/body_site.py
+++ b/app/normalization/body_site.py
@@ -81,4 +81,3 @@ def normalize_body_site(raw_text: str) -> Tuple[str, str]:
         pass
 
     return raw_text.strip(), "PARTIALLY_PRESENT"
-

--- a/app/normalization/body_site.py
+++ b/app/normalization/body_site.py
@@ -1,0 +1,84 @@
+"""Body site normalization aligned with UBERON-style labels."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import requests
+
+BODY_SITE_LOOKUP = {
+    "feces": "feces",
+    "fecal": "feces",
+    "stool": "feces",
+    "gut": "feces",
+    "intestine": "feces",
+    "intestinal": "feces",
+    "colon": "colon",
+    "colonic": "colon",
+    "rectal": "rectum",
+    "rectum": "rectum",
+    "saliva": "saliva",
+    "salivary": "saliva",
+    "oral": "saliva",
+    "mouth": "saliva",
+    "dental": "saliva",
+    "tongue": "tongue",
+    "buccal": "cheek",
+    "vagina": "vagina",
+    "vaginal": "vagina",
+    "cervical": "uterine cervix",
+    "uterine": "uterus",
+    "skin": "skin",
+    "cutaneous": "skin",
+    "dermal": "skin",
+    "lung": "lung",
+    "pulmonary": "lung",
+    "bronchial": "bronchus",
+    "nasal": "nasal cavity",
+    "nasopharyngeal": "nasopharynx",
+    "sputum": "lung",
+    "blood": "blood",
+    "serum": "blood",
+    "plasma": "blood",
+    "urine": "urine",
+    "urinary": "urinary bladder",
+    "bladder": "urinary bladder",
+}
+
+OLS_SEARCH_URL = "https://www.ebi.ac.uk/ols4/api/search"
+
+
+def normalize_body_site(raw_text: str) -> Tuple[str, str]:
+    """Return normalized body site and extraction status."""
+    if not raw_text or raw_text.strip() == "":
+        return "", "ABSENT"
+
+    lowered = raw_text.lower()
+    matched_sites = [value for key, value in BODY_SITE_LOOKUP.items() if key in lowered]
+    unique_sites = list(dict.fromkeys(matched_sites))
+
+    if len(unique_sites) == 1:
+        return unique_sites[0], "PRESENT"
+    if len(unique_sites) > 1:
+        return unique_sites[0], "PARTIALLY_PRESENT"
+
+    try:
+        params = {
+            "q": raw_text.strip(),
+            "ontology": "uberon",
+            "fieldList": "label,obo_id",
+            "rows": 1,
+            "exact": "false",
+        }
+        response = requests.get(OLS_SEARCH_URL, params=params, timeout=5)
+        response.raise_for_status()
+        docs = response.json().get("response", {}).get("docs", [])
+        if docs:
+            label = docs[0].get("label", "")
+            if label:
+                return label, "PRESENT"
+    except Exception:
+        pass
+
+    return raw_text.strip(), "PARTIALLY_PRESENT"
+

--- a/app/normalization/condition.py
+++ b/app/normalization/condition.py
@@ -1,0 +1,116 @@
+"""Condition normalization aligned with EFO canonical labels."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import requests
+
+CONDITION_LOOKUP = {
+    "parkinson disease": "Parkinson disease",
+    "parkinson's": "Parkinson disease",
+    "parkinson": "Parkinson disease",
+    "alzheimer disease": "Alzheimer disease",
+    "alzheimer's": "Alzheimer disease",
+    "alzheimer": "Alzheimer disease",
+    "inflammatory bowel": "inflammatory bowel disease",
+    "ibd": "inflammatory bowel disease",
+    "crohn's": "Crohn disease",
+    "crohn": "Crohn disease",
+    "ulcerative colitis": "ulcerative colitis",
+    "colorectal cancer": "colorectal cancer",
+    "colon cancer": "colorectal cancer",
+    "obesity": "obesity",
+    "obese": "obesity",
+    "overweight": "obesity",
+    "type 2 diabetes": "type 2 diabetes mellitus",
+    "t2d": "type 2 diabetes mellitus",
+    "type 1 diabetes": "type 1 diabetes mellitus",
+    "t1d": "type 1 diabetes mellitus",
+    "diabetes": "diabetes mellitus",
+    "autism": "autism spectrum disorder",
+    "asd": "autism spectrum disorder",
+    "multiple sclerosis": "multiple sclerosis",
+    "depression": "major depressive disorder",
+    "anxiety": "anxiety disorder",
+    "covid-19": "COVID-19",
+    "sars-cov-2": "COVID-19",
+    "covid": "COVID-19",
+    "hiv": "HIV infection",
+    "hepatitis": "hepatitis",
+    "liver cirrhosis": "liver cirrhosis",
+    "nonalcoholic fatty liver": "non-alcoholic fatty liver disease",
+    "nafld": "non-alcoholic fatty liver disease",
+    "celiac": "celiac disease",
+    "coeliac": "celiac disease",
+    "asthma": "asthma",
+    "allergy": "allergy",
+    "rheumatoid arthritis": "rheumatoid arthritis",
+    "lupus": "systemic lupus erythematosus",
+    "psoriasis": "psoriasis",
+    "antibiotic": "antibiotic exposure",
+    "healthy": "healthy",
+    "control": "healthy",
+    "normal": "healthy",
+}
+
+OLS_SEARCH_URL = "https://www.ebi.ac.uk/ols4/api/search"
+
+
+def _extract_clean_disease_name(raw_text: str) -> str:
+    strip_phrases = [
+        "patients with",
+        "patient with",
+        "subjects with",
+        "individuals with",
+        "diagnosis of",
+        "diagnosed with",
+        "suffering from",
+        "history of",
+        "associated with",
+        "related to",
+        "study of",
+        "analysis of",
+    ]
+    text = raw_text.lower()
+    for phrase in strip_phrases:
+        text = text.replace(phrase, "")
+    return text.strip()
+
+
+def normalize_condition(raw_text: str) -> Tuple[str, str]:
+    """Return normalized condition and extraction status."""
+    if not raw_text or raw_text.strip() == "":
+        return "", "ABSENT"
+
+    lowered = raw_text.lower()
+    match = None
+    match_len = 0
+    for key, value in CONDITION_LOOKUP.items():
+        if key in lowered and len(key) > match_len:
+            match = value
+            match_len = len(key)
+    if match:
+        return match, "PRESENT"
+
+    clean_term = _extract_clean_disease_name(raw_text)
+    try:
+        params = {
+            "q": clean_term,
+            "ontology": "efo",
+            "fieldList": "label,obo_id",
+            "rows": 1,
+            "exact": "false",
+        }
+        response = requests.get(OLS_SEARCH_URL, params=params, timeout=5)
+        response.raise_for_status()
+        docs = response.json().get("response", {}).get("docs", [])
+        if docs:
+            label = docs[0].get("label", "")
+            if label:
+                return label, "PRESENT"
+    except Exception:
+        pass
+
+    return raw_text.strip(), "PARTIALLY_PRESENT"
+

--- a/app/normalization/condition.py
+++ b/app/normalization/condition.py
@@ -113,4 +113,3 @@ def normalize_condition(raw_text: str) -> Tuple[str, str]:
         pass
 
     return raw_text.strip(), "PARTIALLY_PRESENT"
-

--- a/app/normalization/host_species.py
+++ b/app/normalization/host_species.py
@@ -1,0 +1,113 @@
+"""Host species normalization aligned with NCBI Taxonomy labels."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Tuple
+
+import requests
+
+SPECIES_LOOKUP = {
+    "human": "Homo sapiens",
+    "humans": "Homo sapiens",
+    "patient": "Homo sapiens",
+    "patients": "Homo sapiens",
+    "participant": "Homo sapiens",
+    "participants": "Homo sapiens",
+    "volunteer": "Homo sapiens",
+    "volunteers": "Homo sapiens",
+    "subject": "Homo sapiens",
+    "subjects": "Homo sapiens",
+    "infant": "Homo sapiens",
+    "infants": "Homo sapiens",
+    "children": "Homo sapiens",
+    "neonate": "Homo sapiens",
+    "neonates": "Homo sapiens",
+    "adult": "Homo sapiens",
+    "adults": "Homo sapiens",
+    "homo sapiens": "Homo sapiens",
+    "mouse": "Mus musculus",
+    "mice": "Mus musculus",
+    "mus musculus": "Mus musculus",
+    "rat": "Rattus norvegicus",
+    "rats": "Rattus norvegicus",
+    "rattus norvegicus": "Rattus norvegicus",
+    "zebrafish": "Danio rerio",
+    "danio rerio": "Danio rerio",
+    "pig": "Sus scrofa",
+    "pigs": "Sus scrofa",
+    "swine": "Sus scrofa",
+    "sus scrofa": "Sus scrofa",
+    "chicken": "Gallus gallus",
+    "gallus gallus": "Gallus gallus",
+    "rabbit": "Oryctolagus cuniculus",
+    "rabbits": "Oryctolagus cuniculus",
+    "dog": "Canis lupus familiaris",
+    "dogs": "Canis lupus familiaris",
+    "canine": "Canis lupus familiaris",
+}
+
+NCBI_TAX_SEARCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+NCBI_TAX_SUMMARY_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+
+
+def _with_api_key(params: dict) -> dict:
+    api_key = os.getenv("NCBI_API_KEY", "").strip()
+    if api_key:
+        params["api_key"] = api_key
+    return params
+
+
+def _rate_limit_delay() -> None:
+    api_key = os.getenv("NCBI_API_KEY", "").strip()
+    # NCBI permits up to 3 req/s without key, up to 10 req/s with key.
+    time.sleep(0.11 if api_key else 0.34)
+
+
+def normalize_host_species(raw_text: str) -> Tuple[str, str]:
+    """Return normalized host species and extraction status."""
+    if not raw_text or raw_text.strip() == "":
+        return "", "ABSENT"
+
+    lowered = raw_text.lower()
+    multi_indicators = [" and ", " & ", "/", " or "]
+    if any(ind in lowered for ind in multi_indicators):
+        for key, value in SPECIES_LOOKUP.items():
+            if key in lowered:
+                return value, "PARTIALLY_PRESENT"
+        return raw_text.strip(), "PARTIALLY_PRESENT"
+
+    for key, value in SPECIES_LOOKUP.items():
+        if key in lowered:
+            return value, "PRESENT"
+
+    try:
+        search_params = _with_api_key(
+            {
+                "db": "taxonomy",
+                "term": raw_text.strip(),
+                "retmode": "json",
+                "retmax": 1,
+            }
+        )
+        search_resp = requests.get(NCBI_TAX_SEARCH_URL, params=search_params, timeout=5)
+        search_resp.raise_for_status()
+        ids = search_resp.json().get("esearchresult", {}).get("idlist", [])
+        _rate_limit_delay()
+        if ids:
+            summary_params = _with_api_key(
+                {"db": "taxonomy", "id": ids[0], "retmode": "json"}
+            )
+            summary_resp = requests.get(
+                NCBI_TAX_SUMMARY_URL, params=summary_params, timeout=5
+            )
+            summary_resp.raise_for_status()
+            sci_name = summary_resp.json()["result"][ids[0]].get("scientificname", "")
+            if sci_name:
+                return sci_name, "PRESENT"
+    except Exception:
+        pass
+
+    return raw_text.strip(), "PARTIALLY_PRESENT"
+

--- a/app/normalization/host_species.py
+++ b/app/normalization/host_species.py
@@ -110,4 +110,3 @@ def normalize_host_species(raw_text: str) -> Tuple[str, str]:
         pass
 
     return raw_text.strip(), "PARTIALLY_PRESENT"
-

--- a/app/normalization/sample_size.py
+++ b/app/normalization/sample_size.py
@@ -105,4 +105,3 @@ def normalize_sample_size(raw_value: Any) -> Tuple[str, str]:
         return str(int(match.group(1).replace(",", ""))), "PRESENT"
 
     return value, "PARTIALLY_PRESENT"
-

--- a/app/normalization/sample_size.py
+++ b/app/normalization/sample_size.py
@@ -1,0 +1,108 @@
+"""Sample size normalization utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Tuple
+
+try:
+    from word2number import w2n
+except Exception:  # pragma: no cover - optional dependency at runtime
+    w2n = None
+
+
+def _simple_word_to_num(text: str) -> int | None:
+    ones = {
+        "zero": 0,
+        "one": 1,
+        "two": 2,
+        "three": 3,
+        "four": 4,
+        "five": 5,
+        "six": 6,
+        "seven": 7,
+        "eight": 8,
+        "nine": 9,
+        "ten": 10,
+        "eleven": 11,
+        "twelve": 12,
+        "thirteen": 13,
+        "fourteen": 14,
+        "fifteen": 15,
+        "sixteen": 16,
+        "seventeen": 17,
+        "eighteen": 18,
+        "nineteen": 19,
+    }
+    tens = {
+        "twenty": 20,
+        "thirty": 30,
+        "forty": 40,
+        "fifty": 50,
+        "sixty": 60,
+        "seventy": 70,
+        "eighty": 80,
+        "ninety": 90,
+    }
+    scales = {"hundred": 100, "thousand": 1000}
+
+    tokens = re.findall(r"[a-z]+", text.lower())
+    if not tokens:
+        return None
+    total = 0
+    current = 0
+    consumed = False
+    for token in tokens:
+        if token in ones:
+            current += ones[token]
+            consumed = True
+        elif token in tens:
+            current += tens[token]
+            consumed = True
+        elif token == "and":
+            continue
+        elif token in scales:
+            consumed = True
+            if current == 0:
+                current = 1
+            current *= scales[token]
+            if token == "thousand":
+                total += current
+                current = 0
+        else:
+            if consumed:
+                break
+    if not consumed:
+        return None
+    return total + current
+
+
+def normalize_sample_size(raw_value: Any) -> Tuple[str, str]:
+    """Return sample size as integer string and extraction status."""
+    if raw_value is None or str(raw_value).strip() in ("", "null", "None"):
+        return "", "ABSENT"
+
+    value = str(raw_value).strip()
+    try:
+        parsed = int(value.replace(",", ""))
+        return str(parsed), "PRESENT"
+    except ValueError:
+        pass
+
+    if w2n is not None:
+        try:
+            parsed = w2n.word_to_num(value)
+            return str(int(parsed)), "PRESENT"
+        except Exception:
+            pass
+    else:
+        parsed = _simple_word_to_num(value)
+        if parsed is not None:
+            return str(parsed), "PRESENT"
+
+    match = re.search(r"\b(\d[\d,]*)\b", value)
+    if match:
+        return str(int(match.group(1).replace(",", ""))), "PRESENT"
+
+    return value, "PARTIALLY_PRESENT"
+

--- a/app/normalization/sequencing_type.py
+++ b/app/normalization/sequencing_type.py
@@ -54,10 +54,11 @@ def normalize_sequencing_type(raw_text: str) -> Tuple[str, str]:
             matched_len = len(key)
 
     if matched:
-        found_types = {value for key, value in SEQUENCING_LOOKUP.items() if key in lowered}
+        found_types = {
+            value for key, value in SEQUENCING_LOOKUP.items() if key in lowered
+        }
         if len(found_types) > 1:
             return matched, "PARTIALLY_PRESENT"
         return matched, "PRESENT"
 
     return raw_text.strip(), "PARTIALLY_PRESENT"
-

--- a/app/normalization/sequencing_type.py
+++ b/app/normalization/sequencing_type.py
@@ -1,0 +1,63 @@
+"""Sequencing type normalization aligned with BugSigDB vocabulary."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+BUGSIGDB_SEQ_VOCAB = ["16S", "shotgun", "WGS", "ITS", "amplicon", "RNA-seq", "other"]
+
+SEQUENCING_LOOKUP = {
+    "16s rrna": "16S",
+    "16s ribosomal": "16S",
+    "16s amplicon": "16S",
+    "v3-v4": "16S",
+    "v4 region": "16S",
+    "16s": "16S",
+    "its1": "ITS",
+    "its2": "ITS",
+    "internal transcribed spacer": "ITS",
+    "18s": "ITS",
+    "its": "ITS",
+    "whole metagenome": "shotgun",
+    "whole-metagenome": "shotgun",
+    "metagenomic shotgun": "shotgun",
+    "shotgun sequencing": "shotgun",
+    "shotgun": "shotgun",
+    "whole genome sequencing": "WGS",
+    "whole-genome sequencing": "WGS",
+    "wgs": "WGS",
+    "metatranscriptomics": "RNA-seq",
+    "metatranscriptomic": "RNA-seq",
+    "transcriptomic": "RNA-seq",
+    "rnaseq": "RNA-seq",
+    "rna-seq": "RNA-seq",
+    "amplicon sequencing": "amplicon",
+    "next-generation sequencing": "amplicon",
+    "ngs": "amplicon",
+    "amplicon": "amplicon",
+    "metagenomics": "shotgun",
+    "metagenomic": "shotgun",
+}
+
+
+def normalize_sequencing_type(raw_text: str) -> Tuple[str, str]:
+    """Return normalized sequencing type and extraction status."""
+    if not raw_text or raw_text.strip() == "":
+        return "", "ABSENT"
+
+    lowered = raw_text.lower()
+    matched = None
+    matched_len = 0
+    for key, value in SEQUENCING_LOOKUP.items():
+        if key in lowered and len(key) > matched_len:
+            matched = value
+            matched_len = len(key)
+
+    if matched:
+        found_types = {value for key, value in SEQUENCING_LOOKUP.items() if key in lowered}
+        if len(found_types) > 1:
+            return matched, "PARTIALLY_PRESENT"
+        return matched, "PRESENT"
+
+    return raw_text.strip(), "PARTIALLY_PRESENT"
+

--- a/app/services/bugsigdb_analyzer.py
+++ b/app/services/bugsigdb_analyzer.py
@@ -126,47 +126,6 @@ def extract_year(pub_date_text: Any) -> int | None:
     match = re.search(r"\b(19|20)\d{2}\b", str(pub_date_text))
     return int(match.group(0)) if match else None
 
-EXTRACTION_PROMPT = """
-You are a biomedical literature analyst specializing in microbiome research.
-Analyze the following PubMed abstract and extract structured metadata.
-Return ONLY a valid JSON object with no markdown, no explanation, no extra text.
-
-ABSTRACT:
-{abstract}
-
-METADATA:
-Title: {title}
-Journal: {journal}
-Year: {year}
-
-Extract the following fields and return as JSON:
-
-{{
-  "host_species_raw": "<species mentioned, e.g. 'Homo sapiens' or 'mice and rats'>",
-  "body_site_raw": "<anatomical location of sample collection, e.g. 'feces' or 'gut and oral cavity'>",
-  "condition_raw": "<disease or condition studied, e.g. 'Parkinson disease' or 'healthy volunteers'>",
-  "sequencing_type_raw": "<sequencing method used, e.g. '16S rRNA gene sequencing' or 'shotgun metagenomics'>",
-  "sample_size_raw": <integer total number of participants/samples, or null if not mentioned>,
-  "has_differential_abundance": <true if paper reports taxa/features significantly more/less abundant between groups, else false>,
-  "differential_abundance_confidence": <float 0.0-1.0 confidence in the above assessment>
-}}
-
-Rules:
-- For host_species_raw: give the species name(s) as mentioned. If multiple species, list all separated by " and ".
-- For body_site_raw: give the anatomical site(s) as mentioned. If multiple, list all separated by " and ".
-- For condition_raw: give only the disease/condition name, stripped of clinical context words like "patients with" or "diagnosed with". If the study compares diseased vs healthy, give the disease name only.
-- For sequencing_type_raw: give only the sequencing method name.
-- For sample_size_raw: give ONLY an integer. If stated as words (e.g. "forty-two"), convert to number. If a range, give the total or larger number.
-- For has_differential_abundance: true ONLY if the abstract explicitly states that specific microbial taxa or features differ statistically between groups.
-- For differential_abundance_confidence: 1.0 if clearly stated, 0.7 if strongly implied, 0.5 if ambiguous, 0.2 if unlikely, 0.0 if clearly absent.
-"""
-
-
-def extract_year(pub_date_text: Any) -> int | None:
-    """Extract year from publication date strings like MedlineDate values."""
-    match = re.search(r"\b(19|20)\d{2}\b", str(pub_date_text))
-    return int(match.group(0)) if match else None
-
 
 def _build_field_result(value: Any, status: str, confidence: float = 1.0) -> Dict[str, Any]:
     return {
@@ -257,73 +216,6 @@ def _normalize_extracted_fields(field_results: Dict[str, Dict[str, Any]]) -> Dic
         normalized[key] = current
 
     return normalized
-
-
-def _build_field_result(value: Any, status: str, confidence: float = 1.0) -> Dict[str, Any]:
-    return {
-        "value": "" if status == "ABSENT" else ("" if value is None else str(value)),
-        "status": status,
-        "confidence": float(confidence),
-        "reason_if_missing": "" if status != "ABSENT" else "Information not found in the paper",
-    }
-
-
-def _parse_json_object(raw_text: str) -> Dict[str, Any]:
-    if not raw_text:
-        return {}
-    try:
-        return json.loads(raw_text)
-    except Exception:
-        start = raw_text.find("{")
-        end = raw_text.rfind("}") + 1
-        if start != -1 and end > start:
-            try:
-                return json.loads(raw_text[start:end])
-            except Exception:
-                return {}
-    return {}
-
-
-async def _extract_structured_metadata(
-    *, context_text: str, title: str, journal: str, year: Any
-) -> Dict[str, Any]:
-    """Run one unified extraction call and return parsed JSON dict."""
-    unified_qa = get_unified_qa()
-    if unified_qa is None:
-        return {}
-
-    prompt = EXTRACTION_PROMPT.format(
-        abstract=context_text or "",
-        title=title or "",
-        journal=journal or "",
-        year=year if year is not None else "",
-    )
-    chat_call = unified_qa.chat(prompt)
-    response = (
-        await asyncio.wait_for(chat_call, timeout=ANALYSIS_TIMEOUT)
-        if asyncio.iscoroutine(chat_call)
-        else chat_call
-    )
-    return _parse_json_object(response.get("text", ""))
-
-
-def _field_results_from_unified_payload(payload: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
-    """Map unified prompt JSON payload to internal field structure."""
-    host_val, host_status = normalize_host_species(payload.get("host_species_raw"))
-    body_val, body_status = normalize_body_site(payload.get("body_site_raw"))
-    cond_val, cond_status = normalize_condition(payload.get("condition_raw"))
-    seq_val, seq_status = normalize_sequencing_type(payload.get("sequencing_type_raw"))
-    sample_val, sample_status = normalize_sample_size(payload.get("sample_size_raw"))
-
-    return {
-        "host_species": _build_field_result(host_val, host_status),
-        "body_site": _build_field_result(body_val, body_status),
-        "condition": _build_field_result(cond_val, cond_status),
-        "sequencing_type": _build_field_result(seq_val, seq_status),
-        "sample_size": _build_field_result(sample_val, sample_status),
-        # Keep existing field for backward compatibility with API consumers.
-        "taxa_level": create_empty_field_result("taxa_level"),
-    }
 
 
 async def analyze_paper_simple(pmid: str) -> Optional[Dict[str, Any]]:

--- a/app/services/bugsigdb_analyzer.py
+++ b/app/services/bugsigdb_analyzer.py
@@ -10,7 +10,13 @@ import asyncio
 import json
 import re
 
+from app.normalization.body_site import normalize_body_site
+from app.normalization.condition import normalize_condition
+from app.normalization.host_species import normalize_host_species
+from app.normalization.sample_size import normalize_sample_size
+from app.normalization.sequencing_type import normalize_sequencing_type
 from app.models.unified_qa import UnifiedQA
+from app.services.bugsigdb_check import is_in_bugsigdb
 from app.services.cache_manager import CacheManager
 from app.services.data_retrieval import PubMedRetriever
 from app.utils.config import (
@@ -79,6 +85,246 @@ ESSENTIAL_FIELDS: Dict[str, str] = {
     "sample_size": "How many samples or participants were included in the study?",
 }
 
+EXTRACTION_PROMPT = """
+You are a biomedical literature analyst specializing in microbiome research.
+Analyze the following PubMed abstract and extract structured metadata.
+Return ONLY a valid JSON object with no markdown, no explanation, no extra text.
+
+ABSTRACT:
+{abstract}
+
+METADATA:
+Title: {title}
+Journal: {journal}
+Year: {year}
+
+Extract the following fields and return as JSON:
+
+{{
+  "host_species_raw": "<species mentioned, e.g. 'Homo sapiens' or 'mice and rats'>",
+  "body_site_raw": "<anatomical location of sample collection, e.g. 'feces' or 'gut and oral cavity'>",
+  "condition_raw": "<disease or condition studied, e.g. 'Parkinson disease' or 'healthy volunteers'>",
+  "sequencing_type_raw": "<sequencing method used, e.g. '16S rRNA gene sequencing' or 'shotgun metagenomics'>",
+  "sample_size_raw": <integer total number of participants/samples, or null if not mentioned>,
+  "has_differential_abundance": <true if paper reports taxa/features significantly more/less abundant between groups, else false>,
+  "differential_abundance_confidence": <float 0.0-1.0 confidence in the above assessment>
+}}
+
+Rules:
+- For host_species_raw: give the species name(s) as mentioned. If multiple species, list all separated by " and ".
+- For body_site_raw: give the anatomical site(s) as mentioned. If multiple, list all separated by " and ".
+- For condition_raw: give only the disease/condition name, stripped of clinical context words like "patients with" or "diagnosed with". If the study compares diseased vs healthy, give the disease name only.
+- For sequencing_type_raw: give only the sequencing method name.
+- For sample_size_raw: give ONLY an integer. If stated as words (e.g. "forty-two"), convert to number. If a range, give the total or larger number.
+- For has_differential_abundance: true ONLY if the abstract explicitly states that specific microbial taxa or features differ statistically between groups.
+- For differential_abundance_confidence: 1.0 if clearly stated, 0.7 if strongly implied, 0.5 if ambiguous, 0.2 if unlikely, 0.0 if clearly absent.
+"""
+
+
+def extract_year(pub_date_text: Any) -> int | None:
+    """Extract year from publication date strings like MedlineDate values."""
+    match = re.search(r"\b(19|20)\d{2}\b", str(pub_date_text))
+    return int(match.group(0)) if match else None
+
+EXTRACTION_PROMPT = """
+You are a biomedical literature analyst specializing in microbiome research.
+Analyze the following PubMed abstract and extract structured metadata.
+Return ONLY a valid JSON object with no markdown, no explanation, no extra text.
+
+ABSTRACT:
+{abstract}
+
+METADATA:
+Title: {title}
+Journal: {journal}
+Year: {year}
+
+Extract the following fields and return as JSON:
+
+{{
+  "host_species_raw": "<species mentioned, e.g. 'Homo sapiens' or 'mice and rats'>",
+  "body_site_raw": "<anatomical location of sample collection, e.g. 'feces' or 'gut and oral cavity'>",
+  "condition_raw": "<disease or condition studied, e.g. 'Parkinson disease' or 'healthy volunteers'>",
+  "sequencing_type_raw": "<sequencing method used, e.g. '16S rRNA gene sequencing' or 'shotgun metagenomics'>",
+  "sample_size_raw": <integer total number of participants/samples, or null if not mentioned>,
+  "has_differential_abundance": <true if paper reports taxa/features significantly more/less abundant between groups, else false>,
+  "differential_abundance_confidence": <float 0.0-1.0 confidence in the above assessment>
+}}
+
+Rules:
+- For host_species_raw: give the species name(s) as mentioned. If multiple species, list all separated by " and ".
+- For body_site_raw: give the anatomical site(s) as mentioned. If multiple, list all separated by " and ".
+- For condition_raw: give only the disease/condition name, stripped of clinical context words like "patients with" or "diagnosed with". If the study compares diseased vs healthy, give the disease name only.
+- For sequencing_type_raw: give only the sequencing method name.
+- For sample_size_raw: give ONLY an integer. If stated as words (e.g. "forty-two"), convert to number. If a range, give the total or larger number.
+- For has_differential_abundance: true ONLY if the abstract explicitly states that specific microbial taxa or features differ statistically between groups.
+- For differential_abundance_confidence: 1.0 if clearly stated, 0.7 if strongly implied, 0.5 if ambiguous, 0.2 if unlikely, 0.0 if clearly absent.
+"""
+
+
+def extract_year(pub_date_text: Any) -> int | None:
+    """Extract year from publication date strings like MedlineDate values."""
+    match = re.search(r"\b(19|20)\d{2}\b", str(pub_date_text))
+    return int(match.group(0)) if match else None
+
+
+def _build_field_result(value: Any, status: str, confidence: float = 1.0) -> Dict[str, Any]:
+    return {
+        "value": "" if status == "ABSENT" else ("" if value is None else str(value)),
+        "status": status,
+        "confidence": float(confidence),
+        "reason_if_missing": "" if status != "ABSENT" else "Information not found in the paper",
+    }
+
+
+def _parse_json_object(raw_text: str) -> Dict[str, Any]:
+    if not raw_text:
+        return {}
+    try:
+        return json.loads(raw_text)
+    except Exception:
+        start = raw_text.find("{")
+        end = raw_text.rfind("}") + 1
+        if start != -1 and end > start:
+            try:
+                return json.loads(raw_text[start:end])
+            except Exception:
+                return {}
+    return {}
+
+
+async def _extract_structured_metadata(
+    *, context_text: str, title: str, journal: str, year: Any
+) -> Dict[str, Any]:
+    """Run one unified extraction call and return parsed JSON dict."""
+    unified_qa = get_unified_qa()
+    if unified_qa is None:
+        return {}
+    prompt = EXTRACTION_PROMPT.format(
+        abstract=context_text or "",
+        title=title or "",
+        journal=journal or "",
+        year=year if year is not None else "",
+    )
+    chat_call = unified_qa.chat(prompt)
+    response = await asyncio.wait_for(chat_call, timeout=ANALYSIS_TIMEOUT) if asyncio.iscoroutine(chat_call) else chat_call
+    answer = response.get("text", "")
+    return _parse_json_object(answer)
+
+
+def _field_results_from_unified_payload(payload: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Map unified prompt JSON payload to internal field structure."""
+    host_val, host_status = normalize_host_species(payload.get("host_species_raw"))
+    body_val, body_status = normalize_body_site(payload.get("body_site_raw"))
+    cond_val, cond_status = normalize_condition(payload.get("condition_raw"))
+    seq_val, seq_status = normalize_sequencing_type(payload.get("sequencing_type_raw"))
+    sample_val, sample_status = normalize_sample_size(payload.get("sample_size_raw"))
+
+    return {
+        "host_species": _build_field_result(host_val, host_status),
+        "body_site": _build_field_result(body_val, body_status),
+        "condition": _build_field_result(cond_val, cond_status),
+        "sequencing_type": _build_field_result(seq_val, seq_status),
+        "sample_size": _build_field_result(sample_val, sample_status),
+        # Keep existing field for backward compatibility with API consumers.
+        "taxa_level": create_empty_field_result("taxa_level"),
+    }
+
+
+def _normalize_extracted_fields(field_results: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Normalize raw extracted values to curator-desk canonical forms."""
+    normalized = dict(field_results or {})
+
+    def _field_value(name: str) -> Any:
+        return (normalized.get(name) or {}).get("value")
+
+    mappings = {
+        "host_species": normalize_host_species,
+        "body_site": normalize_body_site,
+        "condition": normalize_condition,
+        "sequencing_type": normalize_sequencing_type,
+        "sample_size": normalize_sample_size,
+    }
+
+    for key, normalizer in mappings.items():
+        current = dict(normalized.get(key) or {})
+        value, status = normalizer(_field_value(key))
+        current["value"] = value
+        current["status"] = status
+        current["confidence"] = float(current.get("confidence", 0.0) or 0.0)
+        if status == "ABSENT":
+            current["value"] = ""
+        normalized[key] = current
+
+    return normalized
+
+
+def _build_field_result(value: Any, status: str, confidence: float = 1.0) -> Dict[str, Any]:
+    return {
+        "value": "" if status == "ABSENT" else ("" if value is None else str(value)),
+        "status": status,
+        "confidence": float(confidence),
+        "reason_if_missing": "" if status != "ABSENT" else "Information not found in the paper",
+    }
+
+
+def _parse_json_object(raw_text: str) -> Dict[str, Any]:
+    if not raw_text:
+        return {}
+    try:
+        return json.loads(raw_text)
+    except Exception:
+        start = raw_text.find("{")
+        end = raw_text.rfind("}") + 1
+        if start != -1 and end > start:
+            try:
+                return json.loads(raw_text[start:end])
+            except Exception:
+                return {}
+    return {}
+
+
+async def _extract_structured_metadata(
+    *, context_text: str, title: str, journal: str, year: Any
+) -> Dict[str, Any]:
+    """Run one unified extraction call and return parsed JSON dict."""
+    unified_qa = get_unified_qa()
+    if unified_qa is None:
+        return {}
+
+    prompt = EXTRACTION_PROMPT.format(
+        abstract=context_text or "",
+        title=title or "",
+        journal=journal or "",
+        year=year if year is not None else "",
+    )
+    chat_call = unified_qa.chat(prompt)
+    response = (
+        await asyncio.wait_for(chat_call, timeout=ANALYSIS_TIMEOUT)
+        if asyncio.iscoroutine(chat_call)
+        else chat_call
+    )
+    return _parse_json_object(response.get("text", ""))
+
+
+def _field_results_from_unified_payload(payload: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Map unified prompt JSON payload to internal field structure."""
+    host_val, host_status = normalize_host_species(payload.get("host_species_raw"))
+    body_val, body_status = normalize_body_site(payload.get("body_site_raw"))
+    cond_val, cond_status = normalize_condition(payload.get("condition_raw"))
+    seq_val, seq_status = normalize_sequencing_type(payload.get("sequencing_type_raw"))
+    sample_val, sample_status = normalize_sample_size(payload.get("sample_size_raw"))
+
+    return {
+        "host_species": _build_field_result(host_val, host_status),
+        "body_site": _build_field_result(body_val, body_status),
+        "condition": _build_field_result(cond_val, cond_status),
+        "sequencing_type": _build_field_result(seq_val, seq_status),
+        "sample_size": _build_field_result(sample_val, sample_status),
+        # Keep existing field for backward compatibility with API consumers.
+        "taxa_level": create_empty_field_result("taxa_level"),
+    }
+
 
 async def analyze_paper_simple(pmid: str) -> Optional[Dict[str, Any]]:
     """Extract BugSigDB fields from a paper.
@@ -127,35 +373,19 @@ async def analyze_paper_simple(pmid: str) -> Optional[Dict[str, Any]]:
             logger.warning(f"No analyzable text found for PMID: {pmid}")
             return None
 
-        has_diff_abund, diff_abund_conf = detect_differential_abundance(analysis_text)
-
-        chunks = None
-        if full_text and len(full_text) > 1000:
-            try:
-                from app.utils.chunking import ChunkingService
-
-                chunker = ChunkingService(chunk_chars=3000, overlap=100)
-                chunks = await chunker.chunk_markdown(
-                    markdown=full_text, doc_name=f"PMID_{pmid}", doc_key=pmid
-                )
-                logger.info(f"Created {len(chunks)} chunks for advanced RAG")
-            except Exception as chunk_error:
-                logger.warning(
-                    f"Failed to create chunks for advanced RAG: {chunk_error}"
-                )
-                chunks = None
-
-        # Analyze each of the 6 essential fields
-        field_results = {}
-        for field_name, question in ESSENTIAL_FIELDS.items():
-            try:
-                field_result = await analyze_single_field(
-                    analysis_text, field_name, question, pmid, chunks=chunks
-                )
-                field_results[field_name] = field_result
-            except Exception as e:
-                logger.error(f"Error analyzing field {field_name} for PMID {pmid}: {e}")
-                field_results[field_name] = create_empty_field_result(field_name)
+        year = extract_year(texts.get("publication_date", ""))
+        payload = await _extract_structured_metadata(
+            context_text=analysis_text,
+            title=title,
+            journal=texts.get("journal", ""),
+            year=year if year is not None else "",
+        )
+        field_results = _field_results_from_unified_payload(payload)
+        try:
+            has_diff_abund = bool(payload.get("has_differential_abundance", False))
+            diff_abund_conf = float(payload.get("differential_abundance_confidence", 0.0))
+        except (TypeError, ValueError):
+            has_diff_abund, diff_abund_conf = detect_differential_abundance(analysis_text)
 
         result = {
             "pmid": pmid,
@@ -163,8 +393,10 @@ async def analyze_paper_simple(pmid: str) -> Optional[Dict[str, Any]]:
             "authors": texts.get("authors", []),
             "journal": texts.get("journal", ""),
             "publication_date": texts.get("publication_date", ""),
+            "year": year if year is not None else "",
             "has_differential_abundance": has_diff_abund,
             "differential_abundance_confidence": diff_abund_conf,
+            "in_bugsigdb": is_in_bugsigdb(pmid),
             "fields": field_results,
             "analysis_timestamp": get_current_timestamp(),
             "model_used": DEFAULT_MODEL,
@@ -257,8 +489,6 @@ async def analyze_paper_with_rag(
             logger.warning(f"No analyzable text found for PMID: {pmid}")
             return None
 
-        has_diff_abund, diff_abund_conf = detect_differential_abundance(analysis_text)
-
         chunks = None
         if use_rag_final and full_text and len(full_text) > 1000:
             try:
@@ -275,32 +505,56 @@ async def analyze_paper_with_rag(
                 )
                 chunks = None
 
-        # Analyze each of the 6 essential fields
-        field_results = {}
-        for field_name, question in ESSENTIAL_FIELDS.items():
-            try:
-                field_result = await analyze_single_field(
-                    analysis_text,
-                    field_name,
-                    question,
-                    pmid,
-                    chunks=chunks if use_rag_final else None,
-                    rag_config=rag_config_dict if use_rag_final else None,
-                )
-                field_results[field_name] = field_result
-            except Exception as e:
-                logger.error(f"Error analyzing field {field_name} for PMID {pmid}: {e}")
-                field_results[field_name] = create_empty_field_result(field_name)
-
         processing_time = time.time() - start_time
+        year = extract_year(texts.get("publication_date", ""))
+        context_for_prompt = analysis_text
+        if use_rag_final and chunks:
+            try:
+                from app.services.advanced_rag import AdvancedRAGService
+
+                rag_service = AdvancedRAGService(
+                    rerank_method=(
+                        rag_config_dict.get("rerank_method", "hybrid")
+                        if rag_config_dict
+                        else "hybrid"
+                    ),
+                    evidence_k=(rag_config_dict.get("evidence_k") if rag_config_dict else None),
+                    max_sources=(rag_config_dict.get("max_sources") if rag_config_dict else None),
+                    use_10_scale=(rag_config_dict.get("use_10_scale", True) if rag_config_dict else True),
+                )
+                context_for_prompt = await rag_service.get_contextual_context(
+                    chunks=chunks,
+                    query="Extract host species, body site, condition, sequencing type, sample size and differential abundance metadata.",
+                    top_k=(rag_config_dict.get("top_k_chunks") if rag_config_dict else None),
+                    evidence_k=(rag_config_dict.get("evidence_k") if rag_config_dict else None),
+                    max_sources=(rag_config_dict.get("max_sources") if rag_config_dict else None),
+                )
+            except Exception as rag_error:
+                logger.warning("Unified prompt RAG context fallback: %s", rag_error)
+
+        payload = await _extract_structured_metadata(
+            context_text=context_for_prompt,
+            title=title,
+            journal=texts.get("journal", ""),
+            year=year if year is not None else "",
+        )
+        field_results = _field_results_from_unified_payload(payload)
+        try:
+            has_diff_abund = bool(payload.get("has_differential_abundance", False))
+            diff_abund_conf = float(payload.get("differential_abundance_confidence", 0.0))
+        except (TypeError, ValueError):
+            has_diff_abund, diff_abund_conf = detect_differential_abundance(analysis_text)
+
         result = {
             "pmid": pmid,
             "title": title,
             "authors": texts.get("authors", []),
             "journal": texts.get("journal", ""),
             "publication_date": texts.get("publication_date", ""),
+            "year": year if year is not None else "",
             "has_differential_abundance": has_diff_abund,
             "differential_abundance_confidence": diff_abund_conf,
+            "in_bugsigdb": is_in_bugsigdb(pmid),
             "fields": field_results,
             "analysis_timestamp": get_current_timestamp(),
             "model_used": DEFAULT_MODEL,

--- a/app/services/bugsigdb_analyzer.py
+++ b/app/services/bugsigdb_analyzer.py
@@ -126,12 +126,16 @@ def extract_year(pub_date_text: Any) -> int | None:
     return int(match.group(0)) if match else None
 
 
-def _build_field_result(value: Any, status: str, confidence: float = 1.0) -> Dict[str, Any]:
+def _build_field_result(
+    value: Any, status: str, confidence: float = 1.0
+) -> Dict[str, Any]:
     return {
         "value": "" if status == "ABSENT" else ("" if value is None else str(value)),
         "status": status,
         "confidence": float(confidence),
-        "reason_if_missing": "" if status != "ABSENT" else "Information not found in the paper",
+        "reason_if_missing": (
+            "" if status != "ABSENT" else "Information not found in the paper"
+        ),
     }
 
 
@@ -165,12 +169,18 @@ async def _extract_structured_metadata(
         year=year if year is not None else "",
     )
     chat_call = unified_qa.chat(prompt)
-    response = await asyncio.wait_for(chat_call, timeout=ANALYSIS_TIMEOUT) if asyncio.iscoroutine(chat_call) else chat_call
+    response = (
+        await asyncio.wait_for(chat_call, timeout=ANALYSIS_TIMEOUT)
+        if asyncio.iscoroutine(chat_call)
+        else chat_call
+    )
     answer = response.get("text", "")
     return _parse_json_object(answer)
 
 
-def _field_results_from_unified_payload(payload: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+def _field_results_from_unified_payload(
+    payload: Dict[str, Any]
+) -> Dict[str, Dict[str, Any]]:
     """Map unified prompt JSON payload to internal field structure."""
     host_val, host_status = normalize_host_species(payload.get("host_species_raw"))
     body_val, body_status = normalize_body_site(payload.get("body_site_raw"))
@@ -189,7 +199,9 @@ def _field_results_from_unified_payload(payload: Dict[str, Any]) -> Dict[str, Di
     }
 
 
-def _normalize_extracted_fields(field_results: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+def _normalize_extracted_fields(
+    field_results: Dict[str, Dict[str, Any]]
+) -> Dict[str, Dict[str, Any]]:
     """Normalize raw extracted values to curator-desk canonical forms."""
     normalized = dict(field_results or {})
 
@@ -413,16 +425,30 @@ async def analyze_paper_with_rag(
                         if rag_config_dict
                         else "hybrid"
                     ),
-                    evidence_k=(rag_config_dict.get("evidence_k") if rag_config_dict else None),
-                    max_sources=(rag_config_dict.get("max_sources") if rag_config_dict else None),
-                    use_10_scale=(rag_config_dict.get("use_10_scale", True) if rag_config_dict else True),
+                    evidence_k=(
+                        rag_config_dict.get("evidence_k") if rag_config_dict else None
+                    ),
+                    max_sources=(
+                        rag_config_dict.get("max_sources") if rag_config_dict else None
+                    ),
+                    use_10_scale=(
+                        rag_config_dict.get("use_10_scale", True)
+                        if rag_config_dict
+                        else True
+                    ),
                 )
                 context_for_prompt = await rag_service.get_contextual_context(
                     chunks=chunks,
                     query="Extract host species, body site, condition, sequencing type, sample size and differential abundance metadata.",
-                    top_k=(rag_config_dict.get("top_k_chunks") if rag_config_dict else None),
-                    evidence_k=(rag_config_dict.get("evidence_k") if rag_config_dict else None),
-                    max_sources=(rag_config_dict.get("max_sources") if rag_config_dict else None),
+                    top_k=(
+                        rag_config_dict.get("top_k_chunks") if rag_config_dict else None
+                    ),
+                    evidence_k=(
+                        rag_config_dict.get("evidence_k") if rag_config_dict else None
+                    ),
+                    max_sources=(
+                        rag_config_dict.get("max_sources") if rag_config_dict else None
+                    ),
                 )
             except Exception as rag_error:
                 logger.warning("Unified prompt RAG context fallback: %s", rag_error)
@@ -436,9 +462,13 @@ async def analyze_paper_with_rag(
         field_results = _field_results_from_unified_payload(payload)
         try:
             has_diff_abund = bool(payload.get("has_differential_abundance", False))
-            diff_abund_conf = float(payload.get("differential_abundance_confidence", 0.0))
+            diff_abund_conf = float(
+                payload.get("differential_abundance_confidence", 0.0)
+            )
         except (TypeError, ValueError):
-            has_diff_abund, diff_abund_conf = detect_differential_abundance(analysis_text)
+            has_diff_abund, diff_abund_conf = detect_differential_abundance(
+                analysis_text
+            )
 
         result = {
             "pmid": pmid,

--- a/app/services/bugsigdb_check.py
+++ b/app/services/bugsigdb_check.py
@@ -59,4 +59,3 @@ def is_in_bugsigdb(pmid: Union[int, str]) -> bool:
     except (ValueError, TypeError):
         return False
     return pmid_int in get_bugsigdb_pmids()
-

--- a/app/services/bugsigdb_check.py
+++ b/app/services/bugsigdb_check.py
@@ -1,0 +1,62 @@
+"""BugSigDB PMID cross-reference helpers with in-process caching."""
+
+from __future__ import annotations
+
+import logging
+import time
+from io import StringIO
+from typing import Optional, Set, Union
+
+import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
+
+BUGSIGDB_DUMP_URL = (
+    "https://raw.githubusercontent.com/waldronlab/BugSigDBExports/devel/full_dump.csv"
+)
+
+_bugsigdb_pmids: Optional[Set[int]] = None
+_cache_loaded_at: float = 0.0
+CACHE_TTL_SECONDS = 3600
+
+
+def get_bugsigdb_pmids(force_refresh: bool = False) -> Set[int]:
+    """Download and cache PMIDs already present in BugSigDB."""
+    global _bugsigdb_pmids, _cache_loaded_at
+    now = time.time()
+    if (
+        not force_refresh
+        and _bugsigdb_pmids is not None
+        and (now - _cache_loaded_at) < CACHE_TTL_SECONDS
+    ):
+        return _bugsigdb_pmids
+
+    try:
+        resp = requests.get(BUGSIGDB_DUMP_URL, timeout=30)
+        resp.raise_for_status()
+        df = pd.read_csv(StringIO(resp.text), usecols=["PMID"], dtype={"PMID": str})
+        pmids: Set[int] = set()
+        for value in df["PMID"].dropna():
+            try:
+                pmids.add(int(str(value).strip()))
+            except ValueError:
+                continue
+        _bugsigdb_pmids = pmids
+        _cache_loaded_at = now
+        return _bugsigdb_pmids
+    except Exception as exc:
+        logger.warning(
+            "Could not fetch BugSigDB dump: %s. Defaulting in_bugsigdb to False.", exc
+        )
+        return set()
+
+
+def is_in_bugsigdb(pmid: Union[int, str]) -> bool:
+    """Return True if PMID exists in BugSigDB export."""
+    try:
+        pmid_int = int(str(pmid).strip())
+    except (ValueError, TypeError):
+        return False
+    return pmid_int in get_bugsigdb_pmids()
+

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -60,6 +60,7 @@ tqdm>=4.65.0
 psutil>=5.9.0
 click>=8.0.1
 watchfiles[watchdog]>=1.0.0
+word2number>=1.1
 
 # --- Curator table (Streamlit) ---
 streamlit>=1.28.0

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -23,7 +23,7 @@ tiktoken>=0.5.0
 accelerate>=0.24.0
 datasets>=2.14.0
 google-generativeai>=0.7.2
-litellm>=1.50.0
+litellm>=1.83.7
 paper-qa>=5.0.0
 
 # --- Vector Database ---

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -39,7 +39,7 @@ typing-extensions>=3.10.0.2
 
 # --- Networking & Web Scraping ---
 requests>=2.31.0
-aiohttp>=3.8.6
+aiohttp>=3.13.4
 beautifulsoup4>=4.12.2
 lxml>=4.9.0
 defusedxml>=0.7.1
@@ -51,7 +51,7 @@ httptools>=0.3.0
 # --- File Processing ---
 openpyxl>=3.1.0
 xlrd>=2.0.1
-python-dotenv>=1.0.0
+python-dotenv>=1.2.2
 PyYAML>=5.4.1
 aiofiles>=0.7.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "datasets>=2.14.0",
     "google-generativeai>=0.7.2",
     "tiktoken>=0.5.0",
-    "litellm>=1.50.0",
+    "litellm>=1.83.7",
     # Paper-QA agent integration
     # Note: paper-qa>=5.0.0 requires Python >=3.11
     # For Python <3.11, install paper-qa>=4.9.0,<5.0.0
@@ -58,12 +58,12 @@ dependencies = [
     "xlrd>=2.0.1",
     # Utilities
     "tqdm>=4.65.0",
-    "python-dotenv>=1.0.0",
+    "python-dotenv>=1.2.2",
     "psutil>=5.9.0",
     # WebSocket dependencies
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.23.2",
-    "aiohttp>=3.8.6",
+    "aiohttp>=3.13.4",
     "websockets>=11.0.3",
     "python-multipart>=0.0.5",
     "aiofiles>=0.7.0",

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1653,8 +1653,12 @@ except Exception as e:
         ]
 
         def _status_or_absent(value: Any) -> str:
-            status = (str(value).strip().upper() if value is not None else "")
-            return status if status in {"PRESENT", "PARTIALLY_PRESENT", "ABSENT"} else "ABSENT"
+            status = str(value).strip().upper() if value is not None else ""
+            return (
+                status
+                if status in {"PRESENT", "PARTIALLY_PRESENT", "ABSENT"}
+                else "ABSENT"
+            )
 
         def _text_or_empty(value: Any) -> str:
             return "" if value is None else str(value).strip()
@@ -1663,7 +1667,9 @@ except Exception as e:
             return "TRUE" if bool(value) else "FALSE"
 
         output = io.StringIO()
-        writer = csv.DictWriter(output, fieldnames=output_columns, extrasaction="ignore")
+        writer = csv.DictWriter(
+            output, fieldnames=output_columns, extrasaction="ignore"
+        )
         writer.writeheader()
 
         seen_pmids = set()
@@ -1688,15 +1694,21 @@ except Exception as e:
                 "Title": _text_or_empty(result.get("title", "")),
                 "Journal": _text_or_empty(result.get("journal", "")),
                 "Year": _text_or_empty(year),
-                "Host Species": _text_or_empty(fields.get("host_species", {}).get("value", "")),
+                "Host Species": _text_or_empty(
+                    fields.get("host_species", {}).get("value", "")
+                ),
                 "Host Species Status": _status_or_absent(
                     fields.get("host_species", {}).get("status", "ABSENT")
                 ),
-                "Body Site": _text_or_empty(fields.get("body_site", {}).get("value", "")),
+                "Body Site": _text_or_empty(
+                    fields.get("body_site", {}).get("value", "")
+                ),
                 "Body Site Status": _status_or_absent(
                     fields.get("body_site", {}).get("status", "ABSENT")
                 ),
-                "Condition": _text_or_empty(fields.get("condition", {}).get("value", "")),
+                "Condition": _text_or_empty(
+                    fields.get("condition", {}).get("value", "")
+                ),
                 "Condition Status": _status_or_absent(
                     fields.get("condition", {}).get("status", "ABSENT")
                 ),
@@ -1706,7 +1718,9 @@ except Exception as e:
                 "Sequencing Type Status": _status_or_absent(
                     fields.get("sequencing_type", {}).get("status", "ABSENT")
                 ),
-                "Sample Size": _text_or_empty(fields.get("sample_size", {}).get("value", "")),
+                "Sample Size": _text_or_empty(
+                    fields.get("sample_size", {}).get("value", "")
+                ),
                 "Sample Size Status": _status_or_absent(
                     fields.get("sample_size", {}).get("status", "ABSENT")
                 ),

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1154,11 +1154,14 @@ except Exception as e:
         """Analyze papers and return results."""
         try:
             import requests
+            from app.services.bugsigdb_check import get_bugsigdb_pmids
 
             results = []
             total = len(pmids)
 
             print(f"🔬 Analyzing {total} paper(s)...")
+            # Warm BugSigDB PMID cache once per run; failures gracefully default to empty set.
+            get_bugsigdb_pmids()
 
             for i, pmid in enumerate(pmids, 1):
                 print(f"[{i}/{total}] Analyzing PMID: {pmid}")
@@ -1629,10 +1632,7 @@ except Exception as e:
         """Get curator-desk compatible CSV content (aligned to Levi spec)."""
         import io
 
-        output = io.StringIO()
-        writer = csv.writer(output)
-
-        headers = [
+        output_columns = [
             "PMID",
             "Title",
             "Journal",
@@ -1649,42 +1649,73 @@ except Exception as e:
             "Sample Size Status",
             "has_differential_abundance",
             "differential_abundance_confidence",
-            # Optional helper columns (safe for curator-desk to ignore)
-            "Host Species Ontology Search",
-            "Body Site Ontology Search",
-            "Condition Ontology Search",
+            "in_bugsigdb",
         ]
-        writer.writerow(headers)
 
+        def _status_or_absent(value: Any) -> str:
+            status = (str(value).strip().upper() if value is not None else "")
+            return status if status in {"PRESENT", "PARTIALLY_PRESENT", "ABSENT"} else "ABSENT"
+
+        def _text_or_empty(value: Any) -> str:
+            return "" if value is None else str(value).strip()
+
+        def _bool_upper(value: Any) -> str:
+            return "TRUE" if bool(value) else "FALSE"
+
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=output_columns, extrasaction="ignore")
+        writer.writeheader()
+
+        seen_pmids = set()
         for result in results:
             fields = result.get("fields", {}) or {}
-            year = self._extract_year(result.get("publication_date", ""))
+            pmid = _text_or_empty(result.get("pmid", ""))
+            if pmid in seen_pmids:
+                continue
+            seen_pmids.add(pmid)
 
-            host_val = fields.get("host_species", {}).get("value", "") or ""
-            body_val = fields.get("body_site", {}).get("value", "") or ""
-            cond_val = fields.get("condition", {}).get("value", "") or ""
+            year = self._extract_year(
+                result.get("year") or result.get("publication_date", "")
+            )
+            confidence = result.get("differential_abundance_confidence", 0.0)
+            try:
+                confidence_str = f"{float(confidence):.2f}"
+            except (TypeError, ValueError):
+                confidence_str = "0.00"
 
-            row = [
-                result.get("pmid", ""),
-                result.get("title", ""),
-                result.get("journal", ""),
-                year,
-                host_val,
-                fields.get("host_species", {}).get("status", "") or "",
-                body_val,
-                fields.get("body_site", {}).get("status", "") or "",
-                cond_val,
-                fields.get("condition", {}).get("status", "") or "",
-                fields.get("sequencing_type", {}).get("value", "") or "",
-                fields.get("sequencing_type", {}).get("status", "") or "",
-                fields.get("sample_size", {}).get("value", "") or "",
-                fields.get("sample_size", {}).get("status", "") or "",
-                bool(result.get("has_differential_abundance", False)),
-                result.get("differential_abundance_confidence", ""),
-                self._ncbi_taxonomy_search_url(str(host_val)),
-                self._ols_search_url("uberon", str(body_val)),
-                self._ols_search_url("efo", str(cond_val)),
-            ]
+            row = {
+                "PMID": pmid,
+                "Title": _text_or_empty(result.get("title", "")),
+                "Journal": _text_or_empty(result.get("journal", "")),
+                "Year": _text_or_empty(year),
+                "Host Species": _text_or_empty(fields.get("host_species", {}).get("value", "")),
+                "Host Species Status": _status_or_absent(
+                    fields.get("host_species", {}).get("status", "ABSENT")
+                ),
+                "Body Site": _text_or_empty(fields.get("body_site", {}).get("value", "")),
+                "Body Site Status": _status_or_absent(
+                    fields.get("body_site", {}).get("status", "ABSENT")
+                ),
+                "Condition": _text_or_empty(fields.get("condition", {}).get("value", "")),
+                "Condition Status": _status_or_absent(
+                    fields.get("condition", {}).get("status", "ABSENT")
+                ),
+                "Sequencing Type": _text_or_empty(
+                    fields.get("sequencing_type", {}).get("value", "")
+                ),
+                "Sequencing Type Status": _status_or_absent(
+                    fields.get("sequencing_type", {}).get("status", "ABSENT")
+                ),
+                "Sample Size": _text_or_empty(fields.get("sample_size", {}).get("value", "")),
+                "Sample Size Status": _status_or_absent(
+                    fields.get("sample_size", {}).get("status", "ABSENT")
+                ),
+                "has_differential_abundance": _bool_upper(
+                    result.get("has_differential_abundance", False)
+                ),
+                "differential_abundance_confidence": confidence_str,
+                "in_bugsigdb": _bool_upper(result.get("in_bugsigdb", False)),
+            }
             writer.writerow(row)
 
         return output.getvalue()

--- a/tests/test_curator_desk_csv_format.py
+++ b/tests/test_curator_desk_csv_format.py
@@ -12,6 +12,7 @@ def test_curator_desk_csv_header_and_core_fields():
                 "publication_date": "2021-05-02",
                 "has_differential_abundance": True,
                 "differential_abundance_confidence": 0.92,
+                "in_bugsigdb": True,
                 "fields": {
                     "host_species": {"value": "Homo sapiens", "status": "PRESENT"},
                     "body_site": {"value": "feces", "status": "PRESENT"},
@@ -29,7 +30,7 @@ def test_curator_desk_csv_header_and_core_fields():
     assert len(lines) == 2
 
     header = lines[0].split(",")
-    assert header[:16] == [
+    assert header == [
         "PMID",
         "Title",
         "Journal",
@@ -46,6 +47,7 @@ def test_curator_desk_csv_header_and_core_fields():
         "Sample Size Status",
         "has_differential_abundance",
         "differential_abundance_confidence",
+        "in_bugsigdb",
     ]
 
     row = lines[1].split(",")
@@ -63,4 +65,6 @@ def test_curator_desk_csv_header_and_core_fields():
     assert row[11] == "PRESENT"
     assert row[12] == "98"
     assert row[13] == "PRESENT"
-    assert row[14] == "True"
+    assert row[14] == "TRUE"
+    assert row[15] == "0.92"
+    assert row[16] == "TRUE"

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,60 @@
+from app.normalization.body_site import normalize_body_site
+from app.normalization.condition import normalize_condition
+from app.normalization.host_species import normalize_host_species
+from app.normalization.sample_size import normalize_sample_size
+from app.normalization.sequencing_type import normalize_sequencing_type
+
+
+def test_host_species_normalization_variants():
+    assert normalize_host_species("humans") == ("Homo sapiens", "PRESENT")
+    assert normalize_host_species("mice model") == ("Mus musculus", "PRESENT")
+    assert normalize_host_species("rats") == ("Rattus norvegicus", "PRESENT")
+    assert normalize_host_species("dogs") == ("Canis lupus familiaris", "PRESENT")
+    assert normalize_host_species("") == ("", "ABSENT")
+    assert normalize_host_species("mice and rats")[1] == "PARTIALLY_PRESENT"
+
+
+def test_body_site_normalization_variants():
+    assert normalize_body_site("stool samples") == ("feces", "PRESENT")
+    assert normalize_body_site("gut microbiome") == ("feces", "PRESENT")
+    assert normalize_body_site("salivary swab") == ("saliva", "PRESENT")
+    assert normalize_body_site("nasal cavity swab") == ("nasal cavity", "PRESENT")
+    assert normalize_body_site("blood plasma")[0] == "blood"
+    assert normalize_body_site("") == ("", "ABSENT")
+
+
+def test_condition_normalization_variants():
+    assert normalize_condition("Parkinson's disease patients") == (
+        "Parkinson disease",
+        "PRESENT",
+    )
+    assert normalize_condition("type 2 diabetes cohort") == (
+        "type 2 diabetes mellitus",
+        "PRESENT",
+    )
+    assert normalize_condition("obese adults") == ("obesity", "PRESENT")
+    assert normalize_condition("healthy controls") == ("healthy", "PRESENT")
+    assert normalize_condition("COVID-19 cases") == ("COVID-19", "PRESENT")
+    assert normalize_condition("") == ("", "ABSENT")
+
+
+def test_sequencing_type_normalization_variants():
+    assert normalize_sequencing_type("16S rRNA gene sequencing") == ("16S", "PRESENT")
+    assert normalize_sequencing_type("whole metagenome shotgun sequencing") == ("shotgun", "PRESENT")
+    assert normalize_sequencing_type("ITS1 sequencing") == ("ITS", "PRESENT")
+    assert normalize_sequencing_type("RNA-seq metatranscriptomics") == (
+        "RNA-seq",
+        "PRESENT",
+    )
+    assert normalize_sequencing_type("") == ("", "ABSENT")
+    assert normalize_sequencing_type("new custom chemistry")[1] == "PARTIALLY_PRESENT"
+
+
+def test_sample_size_normalization_variants():
+    assert normalize_sample_size(98) == ("98", "PRESENT")
+    assert normalize_sample_size("1,200 participants") == ("1200", "PRESENT")
+    assert normalize_sample_size("ninety eight") == ("98", "PRESENT")
+    assert normalize_sample_size("about 65 volunteers") == ("65", "PRESENT")
+    assert normalize_sample_size(None) == ("", "ABSENT")
+    assert normalize_sample_size("unknown sample count")[1] == "PARTIALLY_PRESENT"
+

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -40,7 +40,10 @@ def test_condition_normalization_variants():
 
 def test_sequencing_type_normalization_variants():
     assert normalize_sequencing_type("16S rRNA gene sequencing") == ("16S", "PRESENT")
-    assert normalize_sequencing_type("whole metagenome shotgun sequencing") == ("shotgun", "PRESENT")
+    assert normalize_sequencing_type("whole metagenome shotgun sequencing") == (
+        "shotgun",
+        "PRESENT",
+    )
     assert normalize_sequencing_type("ITS1 sequencing") == ("ITS", "PRESENT")
     assert normalize_sequencing_type("RNA-seq metatranscriptomics") == (
         "RNA-seq",
@@ -57,4 +60,3 @@ def test_sample_size_normalization_variants():
     assert normalize_sample_size("about 65 volunteers") == ("65", "PRESENT")
     assert normalize_sample_size(None) == ("", "ABSENT")
     assert normalize_sample_size("unknown sample count")[1] == "PARTIALLY_PRESENT"
-


### PR DESCRIPTION
Implemented the second pass with the exact unified extraction contract in B`ioAnalyzer` and kept `curator_table_r` fixes stable.

Second-pass changes (unified prompt contract)
In `app/services/bugsigdb_analyzer.py`:

Added the structured `EXTRACTION_PROMPT` matching your required contract with keys:

```
- host_species_raw
- body_site_raw
- condition_raw
- sequencing_type_raw
- sample_size_raw
- has_differential_abundance
- differential_abundance_confidence
- Added robust JSON parsing helper (_parse_json_object) for model output.
```

Added one-shot extractor (`_extract_structured_metadata`) so extraction now happens in one `LLM` call.

Added mapper `(_field_results_from_unified_payload`) that pipes *`_raw` through:

```
- normalize_host_species
- normalize_body_site
- normalize_condition
- normalize_sequencing_type
- normalize_sample_size
- Added extract_year() helper (MedlineDate-friendly regex extraction) and included year in analysis result payload.
```

Updated both:

```
- analyze_paper_simple()
- analyze_paper_with_rag()
```

to use unified extraction payload for fields and DA outputs (with heuristic fallback if DA parse is invalid).

