### PR TITLE
Ontology mappings

### DIFF
--- a/.github/workflows/curator-daily-update.yml
+++ b/.github/workflows/curator-daily-update.yml
@@ -1,0 +1,60 @@
+name: Curator Desk daily update
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      max_results:
+        description: Max PubMed PMIDs to fetch
+        required: false
+        default: "50"
+
+permissions:
+  contents: write
+
+jobs:
+  analyze-and-publish:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.GEMINI_API_KEY != '' && secrets.NCBI_API_KEY != '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Start BioAnalyzer API
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          NCBI_API_KEY: ${{ secrets.NCBI_API_KEY }}
+          EMAIL: ${{ secrets.BIOANALYZER_EMAIL }}
+        run: |
+          docker compose -p bioanalyzer-package up -d --build
+          timeout 120 bash -c 'until curl -sf http://localhost:8000/health; do sleep 3; done'
+
+      - name: Run curator pipeline
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          NCBI_API_KEY: ${{ secrets.NCBI_API_KEY }}
+          EMAIL: ${{ secrets.BIOANALYZER_EMAIL }}
+          BIOANALYZER_API_URL: http://localhost:8000/api/v1
+        run: |
+          python scripts/curator_daily_pipeline.py \
+            --max-results ${{ github.event.inputs.max_results || '50' }} \
+            -o curator_table_r/data/predictions.csv
+
+      - name: Commit predictions
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add curator_table_r/data/predictions.csv results/analyzed_pmids.json
+          git diff --staged --quiet || git commit -m "chore: daily curator predictions update"
+          git push

--- a/app/models/extraction_schemas.py
+++ b/app/models/extraction_schemas.py
@@ -308,6 +308,18 @@ class ExtractedExperiment(BaseModel):
         """Re-derive metadata from fields (call after fields are populated)."""
         self.metadata = ExperimentMetadata.from_fields(self.fields)
 
+    def apply_signature_da_flags(self, signatures: List["MicrobialSignature"]) -> None:
+        """Set differential-abundance flags from extracted microbial signatures."""
+        if not signatures:
+            return
+        self.has_differential_abundance = True
+        confidences = [float(s.confidence or 0.0) for s in signatures]
+        has_stats = any(s.statistical_significance for s in signatures)
+        base_conf = max(confidences) if confidences else 0.6
+        self.differential_abundance_confidence = (
+            min(1.0, base_conf + 0.15) if has_stats else base_conf
+        )
+
 
 # ---------------------------------------------------------------------------
 # StudyAnalysisResult
@@ -414,12 +426,8 @@ class StudyAnalysisResult(BaseModel):
         primary_fields: Dict[str, Dict[str, Any]]
         if self.experiments:
             primary_fields = self.experiments[0].fields.to_legacy_dict()
-            has_da = self.experiments[0].has_differential_abundance
-            da_conf = self.experiments[0].differential_abundance_confidence
         else:
             primary_fields = ExperimentFields().to_legacy_dict()
-            has_da = self.has_differential_abundance
-            da_conf = self.differential_abundance_confidence
 
         return {
             "pmid": self.pmid,
@@ -428,8 +436,8 @@ class StudyAnalysisResult(BaseModel):
             "journal": self.journal,
             "publication_date": self.publication_date,
             "year": self.year if self.year is not None else "",
-            "has_differential_abundance": has_da,
-            "differential_abundance_confidence": da_conf,
+            "has_differential_abundance": self.has_differential_abundance,
+            "differential_abundance_confidence": self.differential_abundance_confidence,
             "in_bugsigdb": self.in_bugsigdb,
             "fields": primary_fields,
             "analysis_timestamp": self.analysis_timestamp.isoformat(),

--- a/app/normalization/taxa_level.py
+++ b/app/normalization/taxa_level.py
@@ -1,0 +1,88 @@
+"""Taxonomic rank normalization aligned with BugSigDB curation vocabulary."""
+
+from __future__ import annotations
+
+import re
+
+from app.normalization.types import NormalizedTerm
+
+BUGSIGDB_TAXA_VOCAB = [
+    "kingdom",
+    "phylum",
+    "class",
+    "order",
+    "family",
+    "genus",
+    "species",
+    "strain",
+    "OTU",
+    "ASV",
+    "operational taxonomic unit",
+    "amplicon sequence variant",
+]
+
+TAXA_LEVEL_LOOKUP = {
+    "operational taxonomic unit": "OTU",
+    "operational taxonomic units": "OTU",
+    "otu": "OTU",
+    "otus": "OTU",
+    "amplicon sequence variant": "ASV",
+    "amplicon sequence variants": "ASV",
+    "asv": "ASV",
+    "asvs": "ASV",
+    "kingdom": "kingdom",
+    "phylum": "phylum",
+    "phyla": "phylum",
+    "class": "class",
+    "order": "order",
+    "family": "family",
+    "families": "family",
+    "genus": "genus",
+    "genera": "genus",
+    "species": "species",
+    "strain": "strain",
+    "subspecies": "species",
+    "16s v": "genus",
+    "v3-v4": "genus",
+    "v4 region": "genus",
+}
+
+
+def _best_match(lowered: str) -> tuple[str, int] | None:
+    matched = None
+    matched_len = 0
+    for key, value in TAXA_LEVEL_LOOKUP.items():
+        if key in lowered and len(key) > matched_len:
+            matched = value
+            matched_len = len(key)
+    if matched is None:
+        return None
+    return matched, matched_len
+
+
+def _found_vocab_types(lowered: str) -> set[str]:
+    return {value for key, value in TAXA_LEVEL_LOOKUP.items() if key in lowered}
+
+
+def normalize_taxa_level(raw_text: str) -> NormalizedTerm:
+    """Return normalized taxonomic rank (text vocab only, no ontology ID)."""
+    if not raw_text or not str(raw_text).strip():
+        return NormalizedTerm.absent()
+
+    lowered = str(raw_text).lower()
+    hit = _best_match(lowered)
+    if not hit:
+        stripped = str(raw_text).strip()
+        if stripped in BUGSIGDB_TAXA_VOCAB:
+            return NormalizedTerm(stripped, "", "PRESENT", 1.0)
+        if re.search(r"\b(rank|taxonomic level|taxa level)\b", lowered):
+            return NormalizedTerm(stripped, "", "PARTIALLY_PRESENT", 0.5)
+        return NormalizedTerm(stripped, "", "PARTIALLY_PRESENT", 0.5)
+
+    matched, _ = hit
+    found_types = _found_vocab_types(lowered)
+    if len(found_types) <= 1:
+        return NormalizedTerm(matched, "", "PRESENT", 1.0)
+
+    # Multiple distinct ranks mentioned (e.g. genus and species)
+    return NormalizedTerm(matched, "", "PARTIALLY_PRESENT", 0.85)

--- a/app/services/agent_orchestrator.py
+++ b/app/services/agent_orchestrator.py
@@ -307,7 +307,7 @@ class AgentOrchestrator:
         for experiment in experiments:
             sigs = await self._extract_signatures(docs, experiment)
             experiment.signatures = sigs
-            # Keep metadata snapshot in sync after field population
+            experiment.apply_signature_da_flags(sigs)
             experiment.sync_metadata()
 
         # Aggregate differential abundance from all experiments
@@ -427,9 +427,11 @@ class AgentOrchestrator:
             from app.normalization.host_species import normalize_host_species
             from app.normalization.sample_size import normalize_sample_size
             from app.normalization.sequencing_type import normalize_sequencing_type
+            from app.normalization.taxa_level import normalize_taxa_level
         except ImportError:
             normalize_host_species = normalize_body_site = normalize_condition = None
             normalize_sequencing_type = normalize_sample_size = None
+            normalize_taxa_level = None
 
         experiments: List[ExtractedExperiment] = []
         current_raw: Dict[str, Any] = {}
@@ -455,7 +457,9 @@ class AgentOrchestrator:
                 sample_size=_field_result_from_raw(
                     current_raw.get("sample_size"), normalize_sample_size
                 ),
-                taxa_level=_field_result_from_raw(current_raw.get("taxa_level")),
+                taxa_level=_field_result_from_raw(
+                    current_raw.get("taxa_level"), normalize_taxa_level
+                ),
             )
             exp = ExtractedExperiment(
                 experiment_id=exp_id,

--- a/app/services/bugsigdb_analyzer.py
+++ b/app/services/bugsigdb_analyzer.py
@@ -45,6 +45,7 @@ import logging
 import re
 import json
 import asyncio
+import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -57,6 +58,7 @@ from app.normalization.condition import normalize_condition
 from app.normalization.host_species import normalize_host_species
 from app.normalization.sample_size import normalize_sample_size
 from app.normalization.sequencing_type import normalize_sequencing_type
+from app.normalization.taxa_level import normalize_taxa_level
 from app.models.unified_qa import UnifiedQA
 from app.services.bugsigdb_check import is_in_bugsigdb
 from app.services.cache_manager import CacheManager
@@ -169,6 +171,7 @@ ESSENTIAL_FIELDS: Dict[str, str] = {
     "body_site": "What body site or anatomical location was sampled for microbiome analysis?",
     "condition": "What disease, treatment, or condition is being studied?",
     "sequencing_type": "What sequencing method or molecular technique was used?",
+    "taxa_level": "What taxonomic level was analysed (e.g. genus, species, OTU)?",
     "sample_size": "How many samples or participants were included in the study?",
 }
 
@@ -202,6 +205,7 @@ Extract the following fields and return as a single JSON object:
   "body_site_raw":                   "<anatomical sample site(s) as written, e.g. 'faeces' or 'gut and oral cavity'>",
   "condition_raw":                   "<disease or condition name only, stripped of clinical preamble>",
   "sequencing_type_raw":             "<sequencing or molecular method name only>",
+  "taxa_level_raw":                  "<taxonomic rank analysed, e.g. 'genus', 'species', 'OTU', 'ASV', or null if not stated>",
   "sample_size_raw":                 <integer total participants/samples, or null if not stated>,
   "has_differential_abundance":      <true if specific microbial taxa are reported as statistically more/less abundant between groups>,
   "differential_abundance_confidence": <float 0.0–1.0 confidence in the above>
@@ -215,6 +219,8 @@ Rules:
   If the study compares diseased vs. healthy controls, give the disease name only.
 - sequencing_type_raw: Give the sequencing or molecular method name only. Prefer METHODS if sections are present, otherwise extract from any available text. Give the method name exactly as written
   (e.g. "16S rRNA gene sequencing", "shotgun metagenomics", "whole-genome sequencing").
+- taxa_level_raw     : Give the taxonomic rank analysed (e.g. genus, species, phylum, OTU, ASV). Prefer METHODS or RESULTS if sections are present.
+  If multiple ranks are reported, give the finest rank stated. If not stated, return null.
 - sample_size_raw    : Give ONLY an integer. Prefer METHODS if sections are present, otherwise extract from any available text. Convert word-numbers
   (e.g. "forty-two" → 42). If a range or multiple cohorts, give the total or largest number.
   If completely absent from the paper, return null.
@@ -564,6 +570,27 @@ def _heuristic_payload_from_text(text: str) -> Dict[str, Any]:
     elif "sequencing" in lower:
         sequencing_type_raw = "sequencing"
 
+    taxa_level_raw = None
+    for term in [
+        "operational taxonomic unit",
+        "amplicon sequence variant",
+        "otu",
+        "asv",
+        "species level",
+        "genus level",
+        "phylum level",
+        "family level",
+        "species",
+        "genus",
+        "phylum",
+        "family",
+        "class",
+        "order",
+    ]:
+        if term in lower:
+            taxa_level_raw = term
+            break
+
     sample_size_raw: Optional[int] = None
     n_match = re.search(r"\bn\s*=\s*(\d{1,5})\b", lower)
     if n_match:
@@ -584,6 +611,7 @@ def _heuristic_payload_from_text(text: str) -> Dict[str, Any]:
         "body_site_raw": body_site_raw,
         "condition_raw": condition_raw,
         "sequencing_type_raw": sequencing_type_raw,
+        "taxa_level_raw": taxa_level_raw,
         "sample_size_raw": sample_size_raw,
         "has_differential_abundance": bool(
             re.search(
@@ -598,6 +626,21 @@ def _heuristic_payload_from_text(text: str) -> Dict[str, Any]:
         ),
         "_source": "heuristic",
     }
+
+
+def _build_curation_summary(field_results: Dict[str, Dict[str, Any]]) -> str:
+    """Brief curator-facing summary from normalized field values."""
+    parts: List[str] = []
+    condition = field_results.get("condition", {})
+    if condition.get("status") != "ABSENT" and condition.get("value"):
+        parts.append(f"Condition: {condition['value']}.")
+    host = field_results.get("host_species", {})
+    body = field_results.get("body_site", {})
+    if host.get("status") != "ABSENT" and host.get("value"):
+        parts.append(f"Host: {host['value']}.")
+    if body.get("status") != "ABSENT" and body.get("value"):
+        parts.append(f"Body site: {body['value']}.")
+    return " ".join(parts).strip()
 
 
 def _postprocess_field_results(
@@ -696,6 +739,7 @@ def _field_results_from_unified_payload(
     body_term = normalize_body_site(payload.get("body_site_raw"))
     cond_term = normalize_condition(payload.get("condition_raw"))
     seq_term = normalize_sequencing_type(payload.get("sequencing_type_raw"))
+    taxa_term = normalize_taxa_level(payload.get("taxa_level_raw"))
     samp_term = normalize_sample_size(payload.get("sample_size_raw"))
 
     field_results = {
@@ -704,7 +748,7 @@ def _field_results_from_unified_payload(
         "condition": _build_field_result_from_term(cond_term),
         "sequencing_type": _build_field_result_from_term(seq_term),
         "sample_size": _build_field_result_from_term(samp_term),
-        "taxa_level": create_empty_field_result("taxa_level"),
+        "taxa_level": _build_field_result_from_term(taxa_term),
     }
 
     # Heuristic payloads get a confidence cap — they are less reliable
@@ -714,6 +758,7 @@ def _field_results_from_unified_payload(
             "body_site",
             "condition",
             "sequencing_type",
+            "taxa_level",
             "sample_size",
         ):
             field = field_results.get(key, {})
@@ -802,6 +847,7 @@ async def analyze_paper_simple(
             logger.info("Force-refresh for PMID %s; bypassing cache", pmid)
 
         # ── Retrieve content ───────────────────────────────────────────────
+        start_time = time.time()
         logger.info("Starting simple analysis for PMID %s", pmid)
         texts = await pubmed_retriever.get_texts_for_analysis_async(pmid)
 
@@ -840,6 +886,8 @@ async def analyze_paper_simple(
             payload, analysis_text
         )
 
+        processing_time = time.time() - start_time
+
         # ── Assemble result dict ───────────────────────────────────────────
         # Key names here are the single source of truth — data.R reads these.
         result: Dict[str, Any] = {
@@ -853,11 +901,15 @@ async def analyze_paper_simple(
             "differential_abundance_confidence": diff_abund_conf,
             "in_bugsigdb": is_in_bugsigdb(pmid),
             "fields": field_results,
+            "curation_summary": _build_curation_summary(field_results),
+            "processing_time": processing_time,
             "analysis_timestamp": _current_timestamp(),
             "model_used": DEFAULT_MODEL,
         }
 
-        logger.info("Simple analysis completed for PMID %s", pmid)
+        logger.info(
+            "Simple analysis completed for PMID %s in %.2fs", pmid, processing_time
+        )
 
         # ── Cache result ───────────────────────────────────────────────────
         try:

--- a/curator_table/app.py
+++ b/curator_table/app.py
@@ -47,8 +47,12 @@ STATUS_COLUMNS = [
     "Body Site Status",
     "Condition Status",
     "Sequencing Type Status",
-    "Taxa Level Status",
     "Sample Size Status",
+]
+MAPPING_CONFIDENCE_COLUMNS = [
+    "Host Species Mapping Confidence",
+    "Body Site Mapping Confidence",
+    "Condition Mapping Confidence",
 ]
 OPTIONS = {
     "valid_states": ["ABSENT", "PARTIALLY_PRESENT", "PRESENT"],
@@ -108,11 +112,29 @@ def _normalize_status(x: str) -> str:
 
 
 def _priority_score(row: pd.Series) -> float:
+    """Confidence-weighted priority score (spec §6.4 + long-term vision)."""
     weights = {"PRESENT": 1.0, "PARTIALLY_PRESENT": 0.5}
-    return sum(
-        weights.get(str(row.get(col, "")).strip().upper(), 0.0)
-        for col in STATUS_COLUMNS
-    )
+    score = 0.0
+    for i, col in enumerate(STATUS_COLUMNS):
+        base = weights.get(str(row.get(col, "")).strip().upper(), 0.0)
+        if base == 0:
+            continue
+        conf = 1.0
+        if i < len(MAPPING_CONFIDENCE_COLUMNS):
+            map_col = MAPPING_CONFIDENCE_COLUMNS[i]
+            if map_col in row.index and pd.notna(row.get(map_col)):
+                try:
+                    conf = float(row.get(map_col))
+                except (TypeError, ValueError):
+                    conf = 1.0
+        score += base * conf
+    if row.get("has_differential_abundance") in (True, "TRUE", "True", 1, "1"):
+        try:
+            da_conf = float(row.get("differential_abundance_confidence", 0) or 0)
+            score += 0.25 * da_conf
+        except (TypeError, ValueError):
+            pass
+    return round(score, 3)
 
 
 # -----------------------------
@@ -163,6 +185,17 @@ def normalize_dataset(df: pd.DataFrame) -> pd.DataFrame:
     for col in STATUS_COLUMNS:
         if col in df.columns:
             df = df.assign(**{col: df[col].apply(_normalize_status)})
+    for col in ("has_differential_abundance", "in_bugsigdb"):
+        if col in df.columns:
+            df[col] = df[col].map(
+                lambda v: str(v).strip().upper() in {"TRUE", "T", "1", "YES"}
+                if pd.notna(v)
+                else False
+            )
+        else:
+            df[col] = False
+    if "differential_abundance_confidence" not in df.columns:
+        df["differential_abundance_confidence"] = 0.0
     df = df.assign(
         **{"Priority Score": df.apply(_priority_score, axis=1)},
         **{"PubMed Link": df["PMID"].apply(_make_pmid_link)},
@@ -234,6 +267,19 @@ def render_filters(df: pd.DataFrame) -> pd.DataFrame:
         if not years.empty:
             min_y, max_y = int(years.min()), int(years.max())
             year_range = st.sidebar.slider("Year range", min_y, max_y, (min_y, max_y))
+    da_only = st.sidebar.checkbox(
+        "Only differential abundance papers",
+        value=True,
+        help="Show papers where has_differential_abundance is TRUE (spec §8.2 default)",
+    )
+    min_da_conf = st.sidebar.slider(
+        "Min differential abundance confidence",
+        0.0,
+        1.0,
+        0.0,
+        0.05,
+    )
+    hide_bugsigdb = st.sidebar.checkbox("Hide papers already in BugSigDB", value=False)
     out = df.copy()
     if search:
         mask = out["PMID"].astype(str).str.contains(search, na=False)
@@ -246,6 +292,12 @@ def render_filters(df: pd.DataFrame) -> pd.DataFrame:
             out = out[out[col].isin(allowed)]
     if year_range and "Year" in out.columns:
         out = out[(out["Year"] >= year_range[0]) & (out["Year"] <= year_range[1])]
+    if da_only and "has_differential_abundance" in out.columns:
+        out = out[out["has_differential_abundance"] == True]  # noqa: E712
+    if min_da_conf > 0 and "differential_abundance_confidence" in out.columns:
+        out = out[out["differential_abundance_confidence"].fillna(0) >= min_da_conf]
+    if hide_bugsigdb and "in_bugsigdb" in out.columns:
+        out = out[out["in_bugsigdb"] != True]  # noqa: E712
     return out
 
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -62,6 +62,13 @@ def _field_ontology_id(fields: dict, key: str) -> str:
     return str(fields.get(key, {}).get("ontology_id", "") or "")
 
 
+def _field_mapping_confidence(fields: dict, key: str) -> str:
+    try:
+        return f"{float(fields.get(key, {}).get('mapping_confidence', 0.0)):.2f}"
+    except (TypeError, ValueError):
+        return "0.00"
+
+
 def _status_normalise(value: Any) -> str:
     s = str(value).strip().upper() if value else ""
     return s if s in {"PRESENT", "PARTIALLY_PRESENT", "ABSENT"} else "ABSENT"
@@ -137,6 +144,7 @@ def _render_csv(results: List[Dict[str, Any]]) -> str:
 
 
 def _render_curator_desk_csv(results: List[Dict[str, Any]]) -> str:
+    # Curator Desk spec §3.1 / §6.2: five prediction fields + ontology IDs + triage flags.
     columns = [
         "PMID",
         "Title",
@@ -145,16 +153,21 @@ def _render_curator_desk_csv(results: List[Dict[str, Any]]) -> str:
         "Host Species",
         "Host Species ID",
         "Host Species Status",
+        "Host Species Mapping Confidence",
         "Body Site",
         "Body Site ID",
         "Body Site Status",
+        "Body Site Mapping Confidence",
         "Condition",
         "Condition ID",
         "Condition Status",
+        "Condition Mapping Confidence",
         "Sequencing Type",
         "Sequencing Type Status",
         "Sample Size",
         "Sample Size Status",
+        "Summary",
+        "Processing Time",
         "has_differential_abundance",
         "differential_abundance_confidence",
         "in_bugsigdb",
@@ -173,6 +186,10 @@ def _render_curator_desk_csv(results: List[Dict[str, Any]]) -> str:
             conf = f"{float(r.get('differential_abundance_confidence', 0.0)):.2f}"
         except (TypeError, ValueError):
             conf = "0.00"
+        try:
+            proc_time = f"{float(r.get('processing_time', 0.0)):.2f}"
+        except (TypeError, ValueError):
+            proc_time = "0.00"
         w.writerow(
             {
                 "PMID": pmid,
@@ -184,15 +201,24 @@ def _render_curator_desk_csv(results: List[Dict[str, Any]]) -> str:
                 "Host Species Status": _status_normalise(
                     _field_val(fields, "host_species", "status")
                 ),
+                "Host Species Mapping Confidence": _field_mapping_confidence(
+                    fields, "host_species"
+                ),
                 "Body Site": _field_val(fields, "body_site"),
                 "Body Site ID": _field_ontology_id(fields, "body_site"),
                 "Body Site Status": _status_normalise(
                     _field_val(fields, "body_site", "status")
                 ),
+                "Body Site Mapping Confidence": _field_mapping_confidence(
+                    fields, "body_site"
+                ),
                 "Condition": _field_val(fields, "condition"),
                 "Condition ID": _field_ontology_id(fields, "condition"),
                 "Condition Status": _status_normalise(
                     _field_val(fields, "condition", "status")
+                ),
+                "Condition Mapping Confidence": _field_mapping_confidence(
+                    fields, "condition"
                 ),
                 "Sequencing Type": _field_val(fields, "sequencing_type"),
                 "Sequencing Type Status": _status_normalise(
@@ -202,6 +228,8 @@ def _render_curator_desk_csv(results: List[Dict[str, Any]]) -> str:
                 "Sample Size Status": _status_normalise(
                     _field_val(fields, "sample_size", "status")
                 ),
+                "Summary": r.get("curation_summary", ""),
+                "Processing Time": proc_time,
                 "has_differential_abundance": _bool_upper(
                     r.get("has_differential_abundance")
                 ),

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -84,6 +84,42 @@ def _extract_year(publication_date: Any) -> str:
     return m.group(0) if m else ""
 
 
+def _priority_score(fields: dict) -> float:
+    """
+    Calculate curation priority score (0-5 range).
+    
+    Weights each field by its extraction confidence:
+    - PRESENT: weight = 1.0
+    - PARTIALLY_PRESENT: weight = 0.5
+    - ABSENT: weight = 0.0
+    
+    Score = sum(weight × mapping_confidence) for each of 5 fields.
+    Higher scores = more promising candidates for curation.
+    """
+    field_keys = ["host_species", "body_site", "condition", "sequencing_type", "sample_size"]
+    weights = {"PRESENT": 1.0, "PARTIALLY_PRESENT": 0.5, "ABSENT": 0.0}
+    score = 0.0
+    
+    for key in field_keys:
+        field_data = fields.get(key, {})
+        status = str(field_data.get("status", "ABSENT")).strip().upper()
+        base_weight = weights.get(status, 0.0)
+        
+        if base_weight == 0.0:
+            continue
+        
+        # Get mapping confidence (default to 1.0 if not available)
+        try:
+            mapping_conf = float(field_data.get("mapping_confidence", 1.0))
+            mapping_conf = max(0.0, min(1.0, mapping_conf))  # Clamp to [0, 1]
+        except (TypeError, ValueError):
+            mapping_conf = 1.0
+        
+        score += base_weight * mapping_conf
+    
+    return round(score, 2)
+
+
 def render_results(results: List[Dict[str, Any]], fmt: str) -> str:
     if fmt == "json":
         return json.dumps(results, indent=2, ensure_ascii=False)
@@ -144,7 +180,7 @@ def _render_csv(results: List[Dict[str, Any]]) -> str:
 
 
 def _render_curator_desk_csv(results: List[Dict[str, Any]]) -> str:
-    # Curator Desk spec §3.1 / §6.2: five prediction fields + ontology IDs + triage flags.
+    # Curator Desk spec §3.1 / §6.2: five prediction fields + ontology IDs + triage flags + priority.
     columns = [
         "PMID",
         "Title",
@@ -166,11 +202,12 @@ def _render_curator_desk_csv(results: List[Dict[str, Any]]) -> str:
         "Sequencing Type Status",
         "Sample Size",
         "Sample Size Status",
-        "Summary",
-        "Processing Time",
         "has_differential_abundance",
         "differential_abundance_confidence",
         "in_bugsigdb",
+        "Priority",
+        "Summary",
+        "Processing Time",
     ]
     out = io.StringIO()
     w = csv.DictWriter(out, fieldnames=columns, extrasaction="ignore")
@@ -228,13 +265,14 @@ def _render_curator_desk_csv(results: List[Dict[str, Any]]) -> str:
                 "Sample Size Status": _status_normalise(
                     _field_val(fields, "sample_size", "status")
                 ),
-                "Summary": r.get("curation_summary", ""),
-                "Processing Time": proc_time,
                 "has_differential_abundance": _bool_upper(
                     r.get("has_differential_abundance")
                 ),
                 "differential_abundance_confidence": conf,
                 "in_bugsigdb": _bool_upper(r.get("in_bugsigdb")),
+                "Priority": _priority_score(fields),
+                "Summary": r.get("curation_summary", ""),
+                "Processing Time": proc_time,
             }
         )
     return out.getvalue()

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -87,36 +87,42 @@ def _extract_year(publication_date: Any) -> str:
 def _priority_score(fields: dict) -> float:
     """
     Calculate curation priority score (0-5 range).
-    
+
     Weights each field by its extraction confidence:
     - PRESENT: weight = 1.0
     - PARTIALLY_PRESENT: weight = 0.5
     - ABSENT: weight = 0.0
-    
+
     Score = sum(weight × mapping_confidence) for each of 5 fields.
     Higher scores = more promising candidates for curation.
     """
-    field_keys = ["host_species", "body_site", "condition", "sequencing_type", "sample_size"]
+    field_keys = [
+        "host_species",
+        "body_site",
+        "condition",
+        "sequencing_type",
+        "sample_size",
+    ]
     weights = {"PRESENT": 1.0, "PARTIALLY_PRESENT": 0.5, "ABSENT": 0.0}
     score = 0.0
-    
+
     for key in field_keys:
         field_data = fields.get(key, {})
         status = str(field_data.get("status", "ABSENT")).strip().upper()
         base_weight = weights.get(status, 0.0)
-        
+
         if base_weight == 0.0:
             continue
-        
+
         # Get mapping confidence (default to 1.0 if not available)
         try:
             mapping_conf = float(field_data.get("mapping_confidence", 1.0))
             mapping_conf = max(0.0, min(1.0, mapping_conf))  # Clamp to [0, 1]
         except (TypeError, ValueError):
             mapping_conf = 1.0
-        
+
         score += base_weight * mapping_conf
-    
+
     return round(score, 2)
 
 

--- a/scripts/curator_daily_pipeline.py
+++ b/scripts/curator_daily_pipeline.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Curator Desk daily pipeline (spec §4.3, §7.1, long-term vision).
+
+PubMed discovery search → BioAnalyzer batch analysis → curator_desk_csv export.
+
+Usage:
+  python scripts/curator_daily_pipeline.py --max-results 50 -o results/curator_predictions.csv
+  python scripts/curator_daily_pipeline.py --pmids-file existing_pmids.txt -o out.csv
+
+Requires BioAnalyzer API (BioAnalyzer start) or set BIOANALYZER_API_URL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+from app.pubmed_queries import RECOMMENDED_DISCOVERY_QUERY, SEARCH_PRESETS
+from app.services.data_retrieval import PubMedRetriever
+from scripts.cli import render_results
+
+
+def _load_analyzed_pmids(state_path: Path) -> set[str]:
+    if not state_path.exists():
+        return set()
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+        return set(str(p) for p in data.get("analyzed_pmids", []))
+    except (json.JSONDecodeError, OSError):
+        return set()
+
+
+def _save_analyzed_pmids(state_path: Path, pmids: set[str]) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "analyzed_pmids": sorted(pmids),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _search_pmids(preset: str, query: str | None, max_results: int) -> list[str]:
+    term = query.strip() if query else SEARCH_PRESETS.get(preset, RECOMMENDED_DISCOVERY_QUERY)
+    retriever = PubMedRetriever()
+    return retriever.search(term, max_results=max_results)
+
+
+def _high_confidence_ready(result: dict, min_mapping_conf: float) -> bool:
+    """Papers ready for near-direct BugSigDB import (long-term zero-effort curation)."""
+    fields = result.get("fields") or {}
+    required = ("host_species", "body_site", "condition", "sequencing_type", "sample_size")
+    for key in required:
+        field = fields.get(key) or {}
+        if field.get("status") != "PRESENT":
+            return False
+        if key in ("host_species", "body_site", "condition"):
+            try:
+                if float(field.get("mapping_confidence", 0) or 0) < min_mapping_conf:
+                    return False
+            except (TypeError, ValueError):
+                return False
+    return bool(result.get("has_differential_abundance"))
+
+
+def _analyze_pmids(pmids: list[str], api_base: str, timeout: int) -> list[dict]:
+    results: list[dict] = []
+    for pmid in pmids:
+        url = f"{api_base.rstrip('/')}/analyze/{pmid}"
+        try:
+            resp = requests.get(url, timeout=timeout)
+            if resp.status_code == 200:
+                results.append(resp.json())
+            else:
+                print(f"WARN PMID {pmid}: {resp.status_code} {resp.text[:120]}")
+        except requests.RequestException as exc:
+            print(f"ERROR PMID {pmid}: {exc}")
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Curator Desk daily BioAnalyzer pipeline")
+    parser.add_argument("--preset", choices=["discovery", "broad", "precision"], default="discovery")
+    parser.add_argument("--query", help="Override PubMed query")
+    parser.add_argument("--max-results", type=int, default=50)
+    parser.add_argument("--pmids-file", help="Analyze PMIDs from file instead of searching")
+    parser.add_argument("-o", "--output", default="results/curator_predictions.csv")
+    parser.add_argument("--state-file", default="results/analyzed_pmids.json")
+    parser.add_argument("--skip-analyzed", action="store_true", default=True)
+    parser.add_argument(
+        "--api-url",
+        default=None,
+        help="BioAnalyzer API base (default: BIOANALYZER_API_URL or localhost)",
+    )
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument(
+        "--high-confidence-only",
+        action="store_true",
+        help="Keep only rows with all 5 fields PRESENT, ontology mapping >= threshold, and DA detected",
+    )
+    parser.add_argument("--min-mapping-confidence", type=float, default=0.9)
+    args = parser.parse_args()
+
+    import os
+
+    api_base = args.api_url or os.getenv("BIOANALYZER_API_URL", "http://localhost:8000/api/v1")
+
+    if args.pmids_file:
+        pmids = [
+            line.strip()
+            for line in Path(args.pmids_file).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    else:
+        print(f"Searching PubMed (preset={args.preset}, max={args.max_results})...")
+        pmids = _search_pmids(args.preset, args.query, args.max_results)
+        print(f"Found {len(pmids)} PMID(s)")
+
+    state_path = Path(args.state_file)
+    analyzed = _load_analyzed_pmids(state_path) if args.skip_analyzed else set()
+    new_pmids = [p for p in pmids if p not in analyzed]
+    if not new_pmids:
+        print("No new PMIDs to analyze.")
+        return 0
+
+    print(f"Analyzing {len(new_pmids)} PMID(s) via {api_base}...")
+    results = _analyze_pmids(new_pmids, api_base, args.timeout)
+    if not results:
+        print("No analysis results.")
+        return 1
+
+    if args.high_confidence_only:
+        before = len(results)
+        results = [
+            r
+            for r in results
+            if _high_confidence_ready(r, args.min_mapping_confidence)
+        ]
+        print(
+            f"High-confidence filter: {len(results)}/{before} rows "
+            f"(mapping_confidence >= {args.min_mapping_confidence})"
+        )
+        if not results:
+            print("No rows passed high-confidence filter.")
+            return 1
+
+    csv_text = render_results(results, "curator_desk_csv")
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(csv_text, encoding="utf-8")
+    print(f"Wrote {len(results)} row(s) to {out_path}")
+
+    analyzed.update(new_pmids)
+    _save_analyzed_pmids(state_path, analyzed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/ontology_benchmark.py
+++ b/scripts/eval/ontology_benchmark.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Ontology mapping benchmark (long-term vision: 90%+ precision target).
+
+Evaluates BioAnalyzer normalizers against a gold-standard fixture.
+Extend GOLD_CASES with BugSigDB-validated term pairs for production benchmarking.
+
+Usage:
+  python scripts/eval/ontology_benchmark.py
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+from app.normalization.body_site import normalize_body_site
+from app.normalization.condition import normalize_condition
+from app.normalization.host_species import normalize_host_species
+from app.normalization.sequencing_type import normalize_sequencing_type
+
+
+@dataclass(frozen=True)
+class GoldCase:
+    field: str
+    raw: str
+    expected_label: str
+    expected_ontology_id: str = ""
+
+
+GOLD_CASES = [
+    GoldCase("host_species", "humans", "Homo sapiens", "NCBITaxon:9606"),
+    GoldCase("host_species", "mice", "Mus musculus", "NCBITaxon:10090"),
+    GoldCase("body_site", "stool samples", "feces", "UBERON:0001988"),
+    GoldCase("body_site", "saliva", "saliva", "UBERON:0001836"),
+    GoldCase("condition", "Parkinson's disease", "Parkinson disease", "EFO:0002508"),
+    GoldCase("condition", "type 2 diabetes", "type 2 diabetes mellitus", "EFO:0001360"),
+    GoldCase("condition", "obese adults", "obesity", "EFO:0001073"),
+    GoldCase("sequencing_type", "16S rRNA gene sequencing", "16S", ""),
+    # shotgun and metagenomics are in the same BugSigDB-compatible family
+    GoldCase("sequencing_type", "shotgun metagenomics", "metagenomics", ""),
+]
+
+
+NORMALIZERS = {
+    "host_species": normalize_host_species,
+    "body_site": normalize_body_site,
+    "condition": normalize_condition,
+    "sequencing_type": normalize_sequencing_type,
+}
+
+
+def main() -> int:
+    correct = 0
+    total = len(GOLD_CASES)
+    failures: list[str] = []
+
+    for case in GOLD_CASES:
+        term = NORMALIZERS[case.field](case.raw)
+        label_ok = term.label == case.expected_label
+        id_ok = (case.expected_ontology_id == "" and term.ontology_id == "") or (
+            term.ontology_id == case.expected_ontology_id
+        )
+        if label_ok and id_ok:
+            correct += 1
+        else:
+            failures.append(
+                f"{case.field}({case.raw!r}): got {term.label!r}/{term.ontology_id!r}, "
+                f"expected {case.expected_label!r}/{case.expected_ontology_id!r}"
+            )
+
+    precision = correct / total if total else 0.0
+    print(f"Ontology benchmark: {correct}/{total} correct ({precision:.1%})")
+    for line in failures:
+        print(f"  FAIL {line}")
+
+    target = 0.90
+    if precision < target:
+        print(f"Below target precision {target:.0%} — expand GOLD_CASES and lookup tables.")
+        return 1
+    print(f"Meets target precision {target:.0%}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/feedback_aggregate.py
+++ b/scripts/feedback_aggregate.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Aggregate curator feedback CSVs into a single dataset for model evaluation.
+
+Supports:
+  - Local curator-feedback/*.csv files
+  - Exported GitHub issue bodies containing ```csv blocks
+
+Usage:
+  python scripts/feedback_aggregate.py --input curator_table_r/curator-feedback -o results/aggregated_feedback.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import re
+from pathlib import Path
+
+CSV_BLOCK_RE = re.compile(r"```csv\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def _rows_from_file(path: Path) -> list[dict]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if "```csv" in text.lower():
+        blocks = CSV_BLOCK_RE.findall(text)
+        rows: list[dict] = []
+        for block in blocks:
+            rows.extend(list(csv.DictReader(io.StringIO(block.strip()))))
+        return rows
+    with path.open(encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _accuracy_by_field(rows: list[dict]) -> dict[str, dict[str, int]]:
+    stats: dict[str, dict[str, int]] = {}
+    for row in rows:
+        for key, val in row.items():
+            if not key.startswith("col_feedback__"):
+                continue
+            field = key.replace("col_feedback__", "")
+            stats.setdefault(field, {"Correct": 0, "Incorrect": 0, "Unclear": 0, "Not reviewed": 0})
+            label = (val or "Not reviewed").strip()
+            stats[field][label] = stats[field].get(label, 0) + 1
+    return stats
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Aggregate curator feedback CSVs")
+    parser.add_argument("--input", required=True, help="Directory or file with feedback CSVs")
+    parser.add_argument("-o", "--output", default="results/aggregated_feedback.csv")
+    parser.add_argument("--report", action="store_true", help="Print per-field accuracy summary")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    files: list[Path] = []
+    if input_path.is_file():
+        files = [input_path]
+    elif input_path.is_dir():
+        files = sorted(input_path.glob("**/*.csv")) + sorted(input_path.glob("**/*.md"))
+    else:
+        print(f"Input not found: {input_path}")
+        return 1
+
+    all_rows: list[dict] = []
+    for fp in files:
+        try:
+            all_rows.extend(_rows_from_file(fp))
+        except Exception as exc:
+            print(f"WARN skipping {fp}: {exc}")
+
+    if not all_rows:
+        print("No feedback rows found.")
+        return 1
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames: list[str] = []
+    for row in all_rows:
+        for k in row:
+            if k not in fieldnames:
+                fieldnames.append(k)
+
+    with out_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(all_rows)
+
+    print(f"Aggregated {len(all_rows)} row(s) → {out_path}")
+
+    if args.report:
+        stats = _accuracy_by_field(all_rows)
+        print("\nPer-field prediction feedback:")
+        for field, counts in sorted(stats.items()):
+            reviewed = counts.get("Correct", 0) + counts.get("Incorrect", 0)
+            acc = counts.get("Correct", 0) / reviewed if reviewed else 0.0
+            print(f"  {field}: accuracy={acc:.1%} ({counts})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_curator_desk_csv_format.py
+++ b/tests/test_curator_desk_csv_format.py
@@ -16,21 +16,26 @@ def test_curator_desk_csv_header_and_core_fields():
                 "has_differential_abundance": True,
                 "differential_abundance_confidence": 0.92,
                 "in_bugsigdb": True,
+                "curation_summary": "Condition: Parkinson disease. Host: Homo sapiens.",
+                "processing_time": 1.25,
                 "fields": {
                     "host_species": {
                         "value": "Homo sapiens",
                         "status": "PRESENT",
                         "ontology_id": "NCBITaxon:9606",
+                        "mapping_confidence": 1.0,
                     },
                     "body_site": {
                         "value": "feces",
                         "status": "PRESENT",
                         "ontology_id": "UBERON:0001988",
+                        "mapping_confidence": 1.0,
                     },
                     "condition": {
                         "value": "Parkinson disease",
                         "status": "PRESENT",
                         "ontology_id": "EFO:0002508",
+                        "mapping_confidence": 1.0,
                     },
                     "sequencing_type": {"value": "16S", "status": "PRESENT"},
                     "sample_size": {"value": "98", "status": "PRESENT"},
@@ -51,6 +56,7 @@ def test_curator_desk_csv_header_and_core_fields():
     assert row["Host Species"] == "Homo sapiens"
     assert row["Host Species ID"] == "NCBITaxon:9606"
     assert row["Host Species Status"] == "PRESENT"
+    assert row["Host Species Mapping Confidence"] == "1.00"
     assert row["Body Site"] == "feces"
     assert row["Body Site ID"] == "UBERON:0001988"
     assert row["Body Site Status"] == "PRESENT"
@@ -61,7 +67,11 @@ def test_curator_desk_csv_header_and_core_fields():
     assert row["Sequencing Type Status"] == "PRESENT"
     assert row["Sample Size"] == "98"
     assert row["Sample Size Status"] == "PRESENT"
+    assert row["Summary"] == "Condition: Parkinson disease. Host: Homo sapiens."
+    assert row["Processing Time"] == "1.25"
     assert row["has_differential_abundance"] == "TRUE"
     assert row["differential_abundance_confidence"] == "0.92"
     assert row["in_bugsigdb"] == "TRUE"
-    assert "taxa_level" not in row
+    # Spec §6.2: five prediction fields in curator-desk CSV (taxa_level is API-only)
+    assert "Taxa Level" not in row
+    assert "Taxa Level Status" not in row

--- a/tests/test_field_payload_mapping.py
+++ b/tests/test_field_payload_mapping.py
@@ -1,0 +1,52 @@
+from app.models.extraction_schemas import (
+    ExperimentFields,
+    ExtractedExperiment,
+    MicrobialSignature,
+    StudyAnalysisResult,
+)
+
+
+def test_orchestrator_signature_da_flags():
+    experiment = ExtractedExperiment(
+        experiment_id="exp_1",
+        title="Test",
+        fields=ExperimentFields(),
+    )
+    signatures = [
+        MicrobialSignature(
+            taxon_name="Bacteroides",
+            abundance_change="increased",
+            statistical_significance="p < 0.05",
+            evidence_text="Bacteroides increased in cases",
+            confidence=0.7,
+        )
+    ]
+
+    experiment.apply_signature_da_flags(signatures)
+
+    assert experiment.has_differential_abundance is True
+    assert experiment.differential_abundance_confidence > 0.7
+
+
+def test_study_result_to_analyzer_uses_study_level_da():
+    study = StudyAnalysisResult(
+        pmid="1",
+        study_id="1",
+        source_url="http://example.com",
+        has_differential_abundance=True,
+        differential_abundance_confidence=0.88,
+        experiments=[
+            ExtractedExperiment(
+                experiment_id="exp_1",
+                title="Test",
+                fields=ExperimentFields(),
+                has_differential_abundance=False,
+                differential_abundance_confidence=0.0,
+            )
+        ],
+    )
+
+    flat = study.to_analyzer_result()
+
+    assert flat["has_differential_abundance"] is True
+    assert flat["differential_abundance_confidence"] == 0.88

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -4,6 +4,7 @@ from app.normalization.host_species import normalize_host_species
 from app.normalization.ols import format_ontology_id
 from app.normalization.sample_size import normalize_sample_size
 from app.normalization.sequencing_type import normalize_sequencing_type
+from app.normalization.taxa_level import normalize_taxa_level
 
 
 def test_format_ontology_id():
@@ -115,6 +116,26 @@ def test_sequencing_type_normalization_variants():
 
     t = normalize_sequencing_type("new custom chemistry")
     assert t.status == "PARTIALLY_PRESENT"
+
+
+def test_taxa_level_normalization_variants():
+    t = normalize_taxa_level("genus level analysis")
+    assert t.label == "genus"
+    assert t.status == "PRESENT"
+    assert t.ontology_id == ""
+
+    t = normalize_taxa_level("operational taxonomic units")
+    assert t.label == "OTU"
+    assert t.status == "PRESENT"
+
+    t = normalize_taxa_level("amplicon sequence variants")
+    assert t.label == "ASV"
+
+    t = normalize_taxa_level("species and genus")
+    assert t.status == "PARTIALLY_PRESENT"
+
+    t = normalize_taxa_level("")
+    assert t.status == "ABSENT"
 
 
 def test_sample_size_normalization_variants():

--- a/tests/test_ontology_benchmark.py
+++ b/tests/test_ontology_benchmark.py
@@ -6,10 +6,10 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_ontology_benchmark_meets_target():
-  result = subprocess.run(
-      [sys.executable, str(ROOT / "scripts/eval/ontology_benchmark.py")],
-      capture_output=True,
-      text=True,
-      check=False,
-  )
-  assert result.returncode == 0, result.stdout + result.stderr
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts/eval/ontology_benchmark.py")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_ontology_benchmark.py
+++ b/tests/test_ontology_benchmark.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ontology_benchmark_meets_target():
+  result = subprocess.run(
+      [sys.executable, str(ROOT / "scripts/eval/ontology_benchmark.py")],
+      capture_output=True,
+      text=True,
+      check=False,
+  )
+  assert result.returncode == 0, result.stdout + result.stderr

--- a/txt
+++ b/txt
@@ -1,0 +1,2 @@
+BioAnalyzer start
+BioAnalyzer analyze --file pmids.txt --format curator_desk_csv -o predictions.csv


### PR DESCRIPTION
Ontology mappings (now wired end-to-end)
PubMed analyzer (bugsigdb_analyzer.py)

Extraction prompt now includes taxa_level_raw
All six fields go through normalizers:

- Host → NCBITaxon:*
- Body site → UBERON:*
- Condition → EFO:*

1. Sequencing / taxa level / sample size → controlled vocab (no ontology ID)
2. Heuristic fallback also extracts taxa level
3. Results include curation_summary and processing_time for CSV export
4. New normalizer — app/normalization/taxa_level.py
5. Maps ranks like genus, species, phylum, OTU, ASV.

Agent orchestrator (agent_orchestrator.py)

Uses normalize_taxa_level for URL/PDF analysis
Sets experiment-level DA flags from extracted signatures via apply_signature_da_flags()
Schemas (extraction_schemas.py)

StudyAnalysisResult.to_analyzer_result() uses study-level DA aggregation (not only the first experiment)
