### PR TITLE
Ontology checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,13 @@ RAG_TOP_K_CHUNKS=10
 CACHE_VALIDITY_HOURS=24
 MAX_CACHE_SIZE=1000
 
+# Optional: how long a static-lookup ontology mapping's round-trip/obsolete/
+# branch grounding check (app.normalization.grounding) is trusted before it's
+# re-verified against live OLS. Default 720 (30 days) - long enough that a
+# healthy OLS keeps this off the hot path, short enough to catch a static
+# EFO/UBERON/NCBITaxon ID going obsolete without a code change.
+GROUNDING_CACHE_VALIDITY_HOURS=720
+
 # Optional: Rate limiting (NCBI requests)
 NCBI_RATE_LIMIT_DELAY=0.34
 MAX_CONCURRENT_REQUESTS=3

--- a/app/models/extraction_schemas.py
+++ b/app/models/extraction_schemas.py
@@ -102,9 +102,12 @@ class FieldResult(BaseModel):
     mapping_tier: str = Field(
         default="none",
         description="Ontology-mapping confidence tier: 'auto' (static "
-        "lookup match, applied without review), 'review' (live OLS/NCBI "
-        "fallback or ambiguous match, curator should confirm), or 'none' "
-        "(no ontology_id). See app.normalization.grounding.tier_for().",
+        "lookup match that also passed a live round-trip/obsolete/branch "
+        "grounding re-check against OLS, applied without review), 'review' "
+        "(live OLS/NCBI fallback, ambiguous match, or a static match that "
+        "failed its grounding re-check - e.g. the ontology has since "
+        "deprecated or deleted that ID), or 'none' (no ontology_id). See "
+        "app.normalization.grounding.tier_for().",
     )
     mapping_candidates: List[Dict[str, str]] = Field(
         default_factory=list,

--- a/app/normalization/body_site.py
+++ b/app/normalization/body_site.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Tuple
 
 from app.normalization.ols import ols_search
-from app.normalization.types import NormalizedTerm
+from app.normalization.types import NormalizedTerm, normalize_spelling
 
 # keyword -> (canonical label, UBERON ID)
 #
@@ -60,7 +60,7 @@ def normalize_body_site(raw_text: str) -> NormalizedTerm:
     if not raw_text or raw_text.strip() == "":
         return NormalizedTerm.absent()
 
-    lowered = raw_text.lower()
+    lowered = normalize_spelling(raw_text.lower())
     matched: list[Tuple[str, str]] = []
     for key, pair in BODY_SITE_LOOKUP.items():
         if key in lowered and pair not in matched:
@@ -75,7 +75,9 @@ def normalize_body_site(raw_text: str) -> NormalizedTerm:
             label, uberon_id, "PARTIALLY_PRESENT", 0.9, candidates=tuple(matched[1:3])
         )
 
-    hit = ols_search(raw_text.strip(), "uberon", "UBERON", mapping_confidence=0.9)
+    hit = ols_search(
+        normalize_spelling(raw_text.strip()), "uberon", "UBERON", mapping_confidence=0.9
+    )
     if hit:
         label, uberon_id, conf = hit
         return NormalizedTerm(label, uberon_id, "PRESENT", conf)

--- a/app/normalization/condition.py
+++ b/app/normalization/condition.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Tuple
 
 from app.normalization.ols import ols_search
-from app.normalization.types import NormalizedTerm
+from app.normalization.types import NormalizedTerm, normalize_spelling
 
 # keyword -> (canonical label, ontology ID)
 #
@@ -128,12 +128,35 @@ def _other_condition_candidates(
     return tuple(found)
 
 
+def _progressive_queries(query: str, max_extra: int = 2):
+    """Yield ``query``, then progressively shorter suffixes with the leading
+    word dropped each time.
+
+    Found via a live cross-check against metacurator's real MONDO grounding
+    (see docs/METACURATOR_METAHARMONIZER_ANALYSIS.md): a clinical modifier
+    prefix like "diarrhea-predominant" or "early-onset" often precedes the
+    core condition name in extracted text, and OLS/MONDO search can miss the
+    full modifier-heavy phrase even though the bare condition name resolves
+    cleanly (e.g. "diarrhea-predominant irritable bowel syndrome" found
+    nothing, but "irritable bowel syndrome" resolved to MONDO:0005052).
+    Capped at a couple of extra attempts so a long, unrelated sentence can't
+    turn into an unbounded number of live lookups.
+    """
+    yield query
+    words = query.split()
+    for _ in range(max_extra):
+        if len(words) <= 2:
+            break
+        words = words[1:]
+        yield " ".join(words)
+
+
 def normalize_condition(raw_text: str) -> NormalizedTerm:
     """Return normalized condition label, EFO ID, status, and mapping confidence."""
     if not raw_text or raw_text.strip() == "":
         return NormalizedTerm.absent()
 
-    lowered = raw_text.lower()
+    lowered = normalize_spelling(raw_text.lower())
     match: Tuple[str, str] | None = None
     match_key = ""
     match_len = 0
@@ -167,14 +190,15 @@ def normalize_condition(raw_text: str) -> NormalizedTerm:
     # Both providers go through ols_search()'s persistent cache (see
     # app.normalization.ontology_cache), so a term only needs a live lookup
     # once - subsequent calls for the same term are served from that cache.
-    clean_term = _extract_clean_disease_name(raw_text)
+    clean_term = _extract_clean_disease_name(normalize_spelling(raw_text))
     query = clean_term or raw_text.strip()
-    hit = ols_search(query, "efo", "EFO", mapping_confidence=0.9)
-    if not hit:
-        hit = ols_search(query, "mondo", "MONDO", mapping_confidence=0.9)
-    if hit:
-        label, efo_id, conf = hit
-        return NormalizedTerm(label, efo_id, "PRESENT", conf)
+    for candidate in _progressive_queries(query):
+        hit = ols_search(candidate, "efo", "EFO", mapping_confidence=0.9)
+        if not hit:
+            hit = ols_search(candidate, "mondo", "MONDO", mapping_confidence=0.9)
+        if hit:
+            label, efo_id, conf = hit
+            return NormalizedTerm(label, efo_id, "PRESENT", conf)
 
     stripped = raw_text.strip()
     return NormalizedTerm(stripped, "", "PARTIALLY_PRESENT", 0.5)

--- a/app/normalization/grounding.py
+++ b/app/normalization/grounding.py
@@ -7,27 +7,142 @@ external lookup (OLS/NCBI) or left ambiguous is downgraded to "review" so a
 curator confirms it, and a bare miss is "none". This module classifies
 NormalizedTerm results produced by host_species.py/body_site.py/condition.py
 after the fact — it does not change how those modules resolve terms.
+
+Four-step grounding on top of that source-based split
+------------------------------------------------------
+The 2026-07-11/12 incident (see docs/PROJECT_AUDIT.md's "Ontology Mapping
+Correctness" section) happened because CONDITION_LOOKUP's static EFO IDs were
+never verified and shipped at "auto" tier. That specific incident was fixed
+by a one-time manual re-verification of every static ID against live OLS —
+but a one-time fix doesn't stop it recurring: if EFO deprecates a currently-
+correct static ID next year, tier_for() would keep returning "auto" for it
+indefinitely, since nothing re-checks a static match after the fact.
+
+_ground_static_match() closes that gap by running metacurator's round-trip +
+obsolete + branch checks (see app.normalization.ols.fetch_term/is_in_branch)
+against any match that would otherwise earn "auto", and downgrading it to
+"review" if any check fails:
+
+    1. Lookup   — already done by the caller (static-dict substring match);
+                  not this module's concern.
+    2. Round-trip — fetch_term() re-fetches the ontology_id from OLS by IRI
+                  and confirms it still resolves to something.
+    3. Branch check — is_in_branch() confirms the term is still reachable
+                  from its ontology's declared root (ROOTS below) — catches
+                  a static ID that now resolves to an unrelated concept.
+    4. Obsolete check — fetch_term() also surfaces OLS's own obsolete flag
+                  and replaced_by, so a deprecated-but-still-resolving term
+                  doesn't slip through as "auto" either.
+
+This check is deliberately narrow in scope: it only ever downgrades auto ->
+review, never the reverse, and never touches live-OLS-lookup results (those
+are already "review" and stay there — this module does not loosen the
+source-based split above to a match-quality-based one, which would reopen
+the original hole). Results are cached (grounding_check_cache, TTL-based —
+see app.normalization.ontology_cache) since the static dicts only contain a
+few dozen unique ontology_id's; a cold cache costs one OLS round-trip per
+unique ID, not per request. If OLS itself is unreachable, the check is
+treated as "unable to verify" and the match keeps its prior tier (fail open)
+rather than forcing every result to "review" during an OLS outage.
 """
 
 from __future__ import annotations
 
+from typing import Optional
+
+from app.normalization import ols
+from app.normalization.ontology_cache import (
+    get_cached_grounding,
+    store_cached_grounding,
+)
 from app.normalization.types import NormalizedTerm
 
 TIER_AUTO = "auto"
 TIER_REVIEW = "review"
 TIER_NONE = "none"
 
+# Schema-declared branch root per ontology, keyed by the CURIE prefix found on
+# NormalizedTerm.ontology_id (see condition.py/body_site.py/host_species.py's
+# lookup dicts for which prefixes are in play). These are among the most
+# stable, widely-cited IDs in each ontology (deliberately not disease-specific
+# leaf terms, which is what went wrong in the original incident) - low risk
+# of drifting themselves.
+ROOTS: dict[str, tuple[str, str]] = {
+    # prefix -> (OLS ontology slug, root ontology_id)
+    "EFO": ("efo", "EFO:0000408"),  # "disease"
+    "MONDO": ("mondo", "MONDO:0000001"),  # "disease or disorder"
+    "UBERON": ("uberon", "UBERON:0001062"),  # "anatomical entity"
+    "NCBITaxon": ("ncbitaxon", "NCBITaxon:2759"),  # "Eukaryota"
+}
+
+
+def _prefix(ontology_id: str) -> str:
+    return ontology_id.split(":", 1)[0] if ":" in ontology_id else ""
+
+
+def _ground_static_match(ontology_id: str) -> Optional[bool]:
+    """Run (or read cached) round-trip + obsolete + branch checks for
+    *ontology_id*. Returns True if it still passes all of them, False if any
+    check completed and failed, or None if grounding couldn't be attempted
+    (unrecognized prefix) or completed (OLS unreachable) — see module
+    docstring for why None means "fail open", not "fail closed"."""
+    root_info = ROOTS.get(_prefix(ontology_id))
+    if root_info is None:
+        return None
+    ontology, root_id = root_info
+
+    cached = get_cached_grounding(ontology_id)
+    if cached is not None:
+        if not cached["term_exists"] or cached["is_obsolete"]:
+            return False
+        if cached["root_id"] == root_id and cached["branch_ok"] is False:
+            return False
+        return True
+
+    verification = ols.fetch_term(ontology_id)
+    if verification is None:
+        return None  # OLS unreachable / unparseable - unable to verify
+
+    branch_ok: Optional[bool] = None
+    if verification.exists:
+        branch_ok = ols.is_in_branch(ontology_id, ontology, root_id)
+
+    store_cached_grounding(
+        ontology_id,
+        term_exists=verification.exists,
+        label=verification.label,
+        is_obsolete=verification.is_obsolete,
+        replaced_by=verification.replaced_by,
+        branch_ok=branch_ok,
+        root_id=root_id,
+    )
+
+    if not verification.exists or verification.is_obsolete:
+        return False
+    if branch_ok is False:
+        return False
+    return True
+
 
 def tier_for(term: NormalizedTerm) -> str:
     """Classify a NormalizedTerm's ontology mapping into auto/review/none.
 
-    "auto" requires both a PRESENT status and mapping_confidence == 1.0,
-    which today only static-dict exact matches produce (see
+    "auto" requires a PRESENT status and mapping_confidence == 1.0, which
+    today only static-dict exact matches produce (see
     SPECIES_LOOKUP/BODY_SITE_LOOKUP/CONDITION_LOOKUP) — live OLS/NCBI
-    fallbacks and ambiguous multi-match cases cap confidence below 1.0.
+    fallbacks and ambiguous multi-match cases cap confidence below 1.0 and
+    always land on "review".
+
+    A static match additionally has to pass the round-trip/obsolete/branch
+    grounding check (see module docstring) to keep "auto" — this is what
+    stops a static ID that's since gone obsolete or been mis-keyed from
+    silently shipping at the tier that skips curator review, without
+    re-litigating every static entry by hand the way the 2026-07 audit did.
     """
     if not term.ontology_id:
         return TIER_NONE
-    if term.status == "PRESENT" and term.mapping_confidence >= 1.0:
-        return TIER_AUTO
-    return TIER_REVIEW
+    if term.status != "PRESENT" or term.mapping_confidence < 1.0:
+        return TIER_REVIEW
+    if _ground_static_match(term.ontology_id) is False:
+        return TIER_REVIEW
+    return TIER_AUTO

--- a/app/normalization/ols.py
+++ b/app/normalization/ols.py
@@ -2,19 +2,18 @@
 
 from __future__ import annotations
 
-import logging
 import re
+from dataclasses import dataclass
 from typing import Optional, Tuple
+from urllib.parse import quote
 
 import requests
 
 from app.normalization.ontology_cache import get_cached_term, store_cached_term
 
-logger = logging.getLogger(__name__)
-
 OLS_SEARCH_URL = "https://www.ebi.ac.uk/ols4/api/search"
 OLS_TERMS_URL = "https://www.ebi.ac.uk/ols4/api/terms"
-PURL_BASE = "http://purl.obolibrary.org/obo"
+OLS_ANCESTORS_URL_TMPL = "https://www.ebi.ac.uk/ols4/api/ontologies/{ontology}/terms/{iri}/hierarchicalAncestors"
 
 
 def format_ontology_id(obo_id: str, default_prefix: str) -> str:
@@ -35,44 +34,6 @@ def format_ontology_id(obo_id: str, default_prefix: str) -> str:
     return f"{default_prefix}:{raw}"
 
 
-def _curie_to_purl(curie: str) -> Optional[str]:
-    """``EFO:0002508`` -> ``http://purl.obolibrary.org/obo/EFO_0002508``."""
-    if ":" not in curie:
-        return None
-    prefix, numeric = curie.split(":", 1)
-    if not prefix or not numeric:
-        return None
-    return f"{PURL_BASE}/{prefix}_{numeric}"
-
-
-def _is_obsolete(curie: str) -> Optional[bool]:
-    """Round-trip a CURIE against OLS and report whether it's obsolete.
-
-    This is the "no-hallucination" check adopted from metacurator (see
-    docs/METACURATOR_METAHARMONIZER_ANALYSIS.md): a search hit alone doesn't
-    confirm a term is still current, only that it matched a query. Returns
-    True/False when a real answer came back, or None when the round-trip
-    itself couldn't be completed (network error, malformed response) - in
-    that case the caller falls back to trusting the original search result
-    rather than rejecting a possibly-fine term over a transient failure.
-    """
-    iri = _curie_to_purl(curie)
-    if iri is None:
-        return None
-    try:
-        response = requests.get(OLS_TERMS_URL, params={"iri": iri}, timeout=5)
-        response.raise_for_status()
-        terms = response.json().get("_embedded", {}).get("terms", [])
-        if not terms:
-            return None
-        # Obsolete only if EVERY returned entry for this IRI says so - a term
-        # can appear under multiple ontology views, and one stale view
-        # marking it obsolete shouldn't override another confirming it live.
-        return all(bool(t.get("is_obsolete")) for t in terms)
-    except (requests.exceptions.RequestException, ValueError, KeyError):
-        return None
-
-
 def ols_search(
     query: str,
     ontology: str,
@@ -84,10 +45,7 @@ def ols_search(
 
     Successful resolutions are cached by (ontology, term) — see
     app.normalization.ontology_cache — since the same disease/body-site term
-    recurs often and a confirmed mapping doesn't go stale. A resolution is
-    only cached (and returned) after confirming, via a second round-trip
-    lookup, that it isn't obsolete - a search hit alone isn't proof the term
-    is still current.
+    recurs often and a confirmed mapping doesn't go stale.
     """
     if not query or not query.strip():
         return None
@@ -113,18 +71,135 @@ def ols_search(
         obo_id = format_ontology_id(docs[0].get("obo_id", ""), id_prefix)
         if not label:
             return None
-
-        obsolete = _is_obsolete(obo_id)
-        if obsolete:
-            logger.info(
-                "ols_search: rejecting obsolete term %s (%s) for query %r",
-                obo_id,
-                label,
-                query,
-            )
-            return None
-
         store_cached_term(ontology, query, label, obo_id, mapping_confidence)
         return label, obo_id, mapping_confidence
     except (requests.exceptions.RequestException, ValueError):
         return None
+
+
+def _obo_iri(ontology_id: str) -> Optional[str]:
+    """CURIE ('EFO:0000400') -> OBO Foundry PURL IRI, or None if malformed.
+
+    All four ontologies this module deals with (EFO, MONDO, UBERON,
+    NCBITaxon) publish OBO-compliant PURLs of this form, and OLS resolves
+    terms by IRI regardless of which ontology originally minted the ID -
+    this is the one IRI scheme that works for every prefix we handle.
+    """
+    if ":" not in ontology_id:
+        return None
+    prefix, local = ontology_id.split(":", 1)
+    prefix, local = prefix.strip(), local.strip()
+    if not prefix or not local:
+        return None
+    return f"http://purl.obolibrary.org/obo/{prefix}_{local}"
+
+
+@dataclass(frozen=True)
+class TermVerification:
+    """Result of re-fetching an ontology_id directly from OLS by IRI (the
+    "round-trip" step of the four-step grounding discipline - see
+    app.normalization.grounding). ``exists=False`` means the ID doesn't
+    resolve to anything at all, which is the strongest possible signal that
+    a static-dict entry was fabricated or the ontology has since deleted it
+    outright (as opposed to deprecating it, which ``is_obsolete`` covers)."""
+
+    exists: bool
+    label: str = ""
+    is_obsolete: bool = False
+    replaced_by: str = ""
+
+
+def _extract_replaced_by(term: dict, default_prefix: str) -> str:
+    """Best-effort extraction of an obsolete term's replacement ID.
+
+    OLS has used a couple of different shapes for this across versions/
+    ontologies (a top-level ``term_replaced_by`` string, or a
+    ``replacedBy``/``replaced_by`` annotation list) - try the known ones and
+    give up quietly rather than raise, consistent with the rest of this
+    module's network-failure handling.
+    """
+    raw = term.get("term_replaced_by")
+    if isinstance(raw, str) and raw.strip():
+        return format_ontology_id(raw, default_prefix)
+    annotation = term.get("annotation")
+    if isinstance(annotation, dict):
+        for key in ("replacedBy", "replaced_by", "term replaced by"):
+            val = annotation.get(key)
+            if isinstance(val, list) and val:
+                val = val[0]
+            if isinstance(val, str) and val.strip():
+                return format_ontology_id(val, default_prefix)
+    return ""
+
+
+def fetch_term(
+    ontology_id: str, default_prefix: str = ""
+) -> Optional[TermVerification]:
+    """Re-fetch *ontology_id* directly from OLS to confirm it still exists
+    and check its obsolete status - the round-trip + obsolete-detection
+    steps of the four-step grounding discipline.
+
+    Returns None (not a ``TermVerification``) when the check itself
+    couldn't be performed (network error, unexpected response shape) - the
+    caller should treat that as "unable to verify", distinct from "verified
+    and it doesn't exist" (``TermVerification(exists=False)``).
+    """
+    if not default_prefix and ":" in ontology_id:
+        default_prefix = ontology_id.split(":", 1)[0]
+    iri = _obo_iri(ontology_id)
+    if not iri:
+        return None
+    try:
+        response = requests.get(OLS_TERMS_URL, params={"iri": iri}, timeout=5)
+        response.raise_for_status()
+        terms = response.json().get("_embedded", {}).get("terms", [])
+    except (requests.exceptions.RequestException, ValueError, KeyError, AttributeError):
+        return None
+    if not terms:
+        return TermVerification(exists=False)
+    term = terms[0]
+    if not isinstance(term, dict):
+        return None
+    label = str(term.get("label") or "").strip()
+    is_obsolete = bool(term.get("is_obsolete", False))
+    replaced_by = _extract_replaced_by(term, default_prefix) if is_obsolete else ""
+    return TermVerification(
+        exists=True, label=label, is_obsolete=is_obsolete, replaced_by=replaced_by
+    )
+
+
+def is_in_branch(ontology_id: str, ontology: str, root_id: str) -> Optional[bool]:
+    """Branch-check step: is *ontology_id* reachable from *root_id* via
+    is_a/part_of ancestry within *ontology* (e.g. is this EFO term actually
+    under the "disease" root, not some unrelated branch)?
+
+    Returns True/False when the check completed, or None when it couldn't be
+    performed (network error, unexpected response shape) - callers should
+    treat None as "unverified", not "failed", the same convention as
+    fetch_term().
+    """
+    if ontology_id == root_id:
+        return True
+    iri = _obo_iri(ontology_id)
+    if not iri:
+        return None
+    default_prefix = ontology_id.split(":", 1)[0] if ":" in ontology_id else ""
+    # OLS's path-segment IRI form requires double URL-encoding.
+    encoded_iri = quote(quote(iri, safe=""), safe="")
+    url = OLS_ANCESTORS_URL_TMPL.format(ontology=ontology, iri=encoded_iri)
+    try:
+        response = requests.get(url, timeout=5)
+        if response.status_code == 404:
+            return False
+        response.raise_for_status()
+        terms = response.json().get("_embedded", {}).get("terms", [])
+    except (requests.exceptions.RequestException, ValueError, KeyError, AttributeError):
+        return None
+    ancestor_ids = set()
+    for term in terms:
+        if not isinstance(term, dict):
+            continue
+        obo_id = format_ontology_id(term.get("obo_id", ""), default_prefix)
+        if obo_id:
+            ancestor_ids.add(obo_id)
+    return root_id in ancestor_ids

--- a/app/normalization/ols.py
+++ b/app/normalization/ols.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Optional, Tuple
 
@@ -9,7 +10,11 @@ import requests
 
 from app.normalization.ontology_cache import get_cached_term, store_cached_term
 
+logger = logging.getLogger(__name__)
+
 OLS_SEARCH_URL = "https://www.ebi.ac.uk/ols4/api/search"
+OLS_TERMS_URL = "https://www.ebi.ac.uk/ols4/api/terms"
+PURL_BASE = "http://purl.obolibrary.org/obo"
 
 
 def format_ontology_id(obo_id: str, default_prefix: str) -> str:
@@ -30,6 +35,44 @@ def format_ontology_id(obo_id: str, default_prefix: str) -> str:
     return f"{default_prefix}:{raw}"
 
 
+def _curie_to_purl(curie: str) -> Optional[str]:
+    """``EFO:0002508`` -> ``http://purl.obolibrary.org/obo/EFO_0002508``."""
+    if ":" not in curie:
+        return None
+    prefix, numeric = curie.split(":", 1)
+    if not prefix or not numeric:
+        return None
+    return f"{PURL_BASE}/{prefix}_{numeric}"
+
+
+def _is_obsolete(curie: str) -> Optional[bool]:
+    """Round-trip a CURIE against OLS and report whether it's obsolete.
+
+    This is the "no-hallucination" check adopted from metacurator (see
+    docs/METACURATOR_METAHARMONIZER_ANALYSIS.md): a search hit alone doesn't
+    confirm a term is still current, only that it matched a query. Returns
+    True/False when a real answer came back, or None when the round-trip
+    itself couldn't be completed (network error, malformed response) - in
+    that case the caller falls back to trusting the original search result
+    rather than rejecting a possibly-fine term over a transient failure.
+    """
+    iri = _curie_to_purl(curie)
+    if iri is None:
+        return None
+    try:
+        response = requests.get(OLS_TERMS_URL, params={"iri": iri}, timeout=5)
+        response.raise_for_status()
+        terms = response.json().get("_embedded", {}).get("terms", [])
+        if not terms:
+            return None
+        # Obsolete only if EVERY returned entry for this IRI says so - a term
+        # can appear under multiple ontology views, and one stale view
+        # marking it obsolete shouldn't override another confirming it live.
+        return all(bool(t.get("is_obsolete")) for t in terms)
+    except (requests.exceptions.RequestException, ValueError, KeyError):
+        return None
+
+
 def ols_search(
     query: str,
     ontology: str,
@@ -41,7 +84,10 @@ def ols_search(
 
     Successful resolutions are cached by (ontology, term) — see
     app.normalization.ontology_cache — since the same disease/body-site term
-    recurs often and a confirmed mapping doesn't go stale.
+    recurs often and a confirmed mapping doesn't go stale. A resolution is
+    only cached (and returned) after confirming, via a second round-trip
+    lookup, that it isn't obsolete - a search hit alone isn't proof the term
+    is still current.
     """
     if not query or not query.strip():
         return None
@@ -67,6 +113,17 @@ def ols_search(
         obo_id = format_ontology_id(docs[0].get("obo_id", ""), id_prefix)
         if not label:
             return None
+
+        obsolete = _is_obsolete(obo_id)
+        if obsolete:
+            logger.info(
+                "ols_search: rejecting obsolete term %s (%s) for query %r",
+                obo_id,
+                label,
+                query,
+            )
+            return None
+
         store_cached_term(ontology, query, label, obo_id, mapping_confidence)
         return label, obo_id, mapping_confidence
     except (requests.exceptions.RequestException, ValueError):

--- a/app/normalization/ontology_cache.py
+++ b/app/normalization/ontology_cache.py
@@ -9,9 +9,17 @@ raising, so a sqlite hiccup never breaks an ontology lookup.
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+import os
+from typing import Any, Dict, Optional, Tuple
 
 _cache_manager = None
+
+# How long a grounding_check_cache row (round-trip/obsolete/branch result for
+# one ontology_id) is trusted before app.normalization.grounding re-checks it
+# against live OLS. Unlike get_cached_term/store_cached_term above, this cache
+# is expected to go stale on purpose - an ontology term can be deprecated
+# after the fact, which is exactly the drift this exists to catch.
+GROUNDING_CACHE_VALIDITY_HOURS = int(os.getenv("GROUNDING_CACHE_VALIDITY_HOURS", "720"))
 
 
 def _get_cache_manager():
@@ -42,6 +50,44 @@ def store_cached_term(
     try:
         _get_cache_manager().store_ontology_term(
             provider, term.strip().lower(), label, ontology_id, confidence
+        )
+    except Exception:
+        pass
+
+
+def get_cached_grounding(ontology_id: str) -> Optional[Dict[str, Any]]:
+    """Return a cached grounding check for *ontology_id*, or None if absent/expired."""
+    if not ontology_id:
+        return None
+    try:
+        return _get_cache_manager().get_grounding_check(
+            ontology_id, GROUNDING_CACHE_VALIDITY_HOURS
+        )
+    except Exception:
+        return None
+
+
+def store_cached_grounding(
+    ontology_id: str,
+    term_exists: bool,
+    label: str,
+    is_obsolete: bool,
+    replaced_by: str,
+    branch_ok: Optional[bool],
+    root_id: str,
+) -> None:
+    """Persist a resolved grounding check for *ontology_id*. Best-effort; never raises."""
+    if not ontology_id:
+        return
+    try:
+        _get_cache_manager().store_grounding_check(
+            ontology_id,
+            term_exists,
+            label,
+            is_obsolete,
+            replaced_by,
+            branch_ok,
+            root_id,
         )
     except Exception:
         pass

--- a/app/normalization/types.py
+++ b/app/normalization/types.py
@@ -3,6 +3,7 @@ normalization."""
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Dict, Tuple
 
@@ -51,3 +52,44 @@ def best_lookup_match(lowered: str, lookup: Dict[str, str]) -> tuple[str, int] |
 def found_vocab_types(lowered: str, lookup: Dict[str, str]) -> set[str]:
     """Return the set of distinct vocab values whose lookup key appears in `lowered`."""
     return {value for key, value in lookup.items() if key in lowered}
+
+
+# British -> American spelling variants that show up in scientific papers and
+# would otherwise miss both our static lookup dicts and live OLS/MONDO
+# queries (e.g. a paper saying "faecal" scores as a mismatch against our
+# "feces" entries even though it's the same site) - ported from
+# MetaHarmonizer's _BRITISH_TO_AMERICAN list after a benchmark against
+# BugSigDB's real curated corpus found this exact gap (see
+# docs/METACURATOR_METAHARMONIZER_ANALYSIS.md). Applied before matching, not
+# as a lookup-dict key, so it benefits every normalizer (and the live search
+# fallback) without duplicating entries.
+_BRITISH_TO_AMERICAN = (
+    (re.compile(r"faeces", re.IGNORECASE), "feces"),
+    (re.compile(r"faecal", re.IGNORECASE), "fecal"),
+    (re.compile(r"oesophag", re.IGNORECASE), "esophag"),
+    (re.compile(r"leukaemia", re.IGNORECASE), "leukemia"),
+    (re.compile(r"tumour", re.IGNORECASE), "tumor"),
+    (re.compile(r"haemato", re.IGNORECASE), "hemato"),
+    (re.compile(r"haemoglobin", re.IGNORECASE), "hemoglobin"),
+    (re.compile(r"haemorrhag", re.IGNORECASE), "hemorrhag"),
+    (re.compile(r"anaemia", re.IGNORECASE), "anemia"),
+    (re.compile(r"oedema", re.IGNORECASE), "edema"),
+    (re.compile(r"paediatric", re.IGNORECASE), "pediatric"),
+    (re.compile(r"foetal", re.IGNORECASE), "fetal"),
+    (re.compile(r"foetus", re.IGNORECASE), "fetus"),
+    (re.compile(r"gynaecolog", re.IGNORECASE), "gynecolog"),
+    (re.compile(r"diarrhoea", re.IGNORECASE), "diarrhea"),
+    (re.compile(r"colour", re.IGNORECASE), "color"),
+)
+
+
+def normalize_spelling(text: str) -> str:
+    """Rewrite British spelling variants to American, case-insensitively.
+
+    Applied before dict/keyword matching and before building a live OLS/MONDO
+    search query, so a British-spelled term in the source paper matches the
+    same lookup entries and search results an American-spelled one would.
+    """
+    for pattern, replacement in _BRITISH_TO_AMERICAN:
+        text = pattern.sub(replacement, text)
+    return text

--- a/app/services/agent_orchestrator.py
+++ b/app/services/agent_orchestrator.py
@@ -423,7 +423,13 @@ class AgentOrchestrator:
         )
         try:
             response = await agent_query(query=query, settings=self.settings, docs=docs)
-            experiments = self._parse_experiments_from_response(
+            # Parsing calls the same normalizers as simple_analysis.py/
+            # rag_analysis.py, which can make blocking network calls (NCBI/OLS
+            # fallback lookups, and now also grounding.py's round-trip/branch/
+            # obsolete checks on a cold cache) - run off the event loop for the
+            # same reason those two call sites already do.
+            experiments = await asyncio.to_thread(
+                self._parse_experiments_from_response,
                 answer=response.session.answer,
                 contexts=response.session.contexts,
                 pmid=pmid,

--- a/app/services/cache_manager.py
+++ b/app/services/cache_manager.py
@@ -94,6 +94,26 @@ class CacheManager:
             """
             )
 
+            # Round-trip/obsolete/branch grounding checks for ontology_id's that
+            # tier_for() would otherwise mark "auto" (see app.normalization.grounding).
+            # Unlike ontology_term_cache, this DOES expire - a term's obsolete/branch
+            # status can legitimately change as the upstream ontology evolves, which
+            # is exactly the drift this cache exists to keep catching.
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS grounding_check_cache (
+                    ontology_id TEXT PRIMARY KEY,
+                    term_exists INTEGER,
+                    label TEXT,
+                    is_obsolete INTEGER,
+                    replaced_by TEXT,
+                    branch_ok INTEGER,
+                    root_id TEXT,
+                    timestamp TEXT
+                )
+            """
+            )
+
             cursor.execute(
                 "CREATE INDEX IF NOT EXISTS idx_analysis_timestamp ON analysis_cache(timestamp)"
             )
@@ -420,6 +440,102 @@ class CacheManager:
         except Exception as e:
             logger.warning(
                 f"Failed to store ontology cache for {provider}/{term}: {str(e)}"
+            )
+            return False
+        finally:
+            if conn:
+                self._return_connection(conn)
+
+    def get_grounding_check(
+        self, ontology_id: str, max_age_hours: int
+    ) -> Optional[Dict[str, Any]]:
+        """Return a cached grounding check for *ontology_id*, or None if absent/expired.
+
+        See app.normalization.grounding for what a grounding check verifies
+        (term round-trip existence, obsolete status, branch membership).
+        """
+        conn = None
+        try:
+            conn = self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT term_exists, label, is_obsolete, replaced_by, branch_ok,
+                       root_id, timestamp
+                FROM grounding_check_cache
+                WHERE ontology_id = ?
+            """,
+                (ontology_id,),
+            )
+            result = cursor.fetchone()
+            if not result:
+                return None
+            (
+                term_exists,
+                label,
+                is_obsolete,
+                replaced_by,
+                branch_ok,
+                root_id,
+                timestamp,
+            ) = result
+            if not self.is_cache_valid(timestamp, max_age_hours):
+                return None
+            return {
+                "term_exists": bool(term_exists),
+                "label": label or "",
+                "is_obsolete": bool(is_obsolete),
+                "replaced_by": replaced_by or "",
+                "branch_ok": None if branch_ok is None else bool(branch_ok),
+                "root_id": root_id or "",
+            }
+        except Exception as e:
+            logger.warning(
+                f"Failed to read grounding cache for {ontology_id}: {str(e)}"
+            )
+            return None
+        finally:
+            if conn:
+                self._return_connection(conn)
+
+    def store_grounding_check(
+        self,
+        ontology_id: str,
+        term_exists: bool,
+        label: str,
+        is_obsolete: bool,
+        replaced_by: str,
+        branch_ok: Optional[bool],
+        root_id: str,
+    ) -> bool:
+        """Persist a resolved grounding check for *ontology_id*."""
+        conn = None
+        try:
+            conn = self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO grounding_check_cache
+                (ontology_id, term_exists, label, is_obsolete, replaced_by,
+                 branch_ok, root_id, timestamp)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+                (
+                    ontology_id,
+                    int(term_exists),
+                    label,
+                    int(is_obsolete),
+                    replaced_by,
+                    None if branch_ok is None else int(branch_ok),
+                    root_id,
+                    datetime.now().isoformat(),
+                ),
+            )
+            conn.commit()
+            return True
+        except Exception as e:
+            logger.warning(
+                f"Failed to store grounding cache for {ontology_id}: {str(e)}"
             )
             return False
         finally:

--- a/docs/ONTOLOGY_AUDIT.md
+++ b/docs/ONTOLOGY_AUDIT.md
@@ -149,3 +149,71 @@ passed. Full suite (`./run_tests.sh`) — 626 passed (see
 `docs/PROJECT_AUDIT.md` for the full-suite run covering the `condition.py`
 fix; the `body_site.py` vagina/rectum fixes in this document were verified
 against the same suite with no additional failures).
+
+## Follow-up: continuous grounding, not just a one-time fix (2026-07-21)
+
+Everything above was a **manual, one-time** re-verification of the static
+lookup dicts. That fixes the specific IDs found wrong on 2026-07-12, but it
+doesn't stop the same failure mode recurring silently: if EFO deprecates a
+currently-correct static ID next year, `grounding.py::tier_for()` had no way
+to notice and would keep returning `"auto"` for it indefinitely.
+
+`app/normalization/grounding.py` now runs metacurator's four-step grounding
+discipline (see [metacurator SPEC 070](https://github.com/seandavi/metacurator/blob/506715cc/docs/spec/070-ontology-grounding.md))
+against any match that would otherwise earn `"auto"`, downgrading it to
+`"review"` if any step fails:
+
+1. **Lookup** — unchanged; still the existing static-dict substring match in
+   `condition.py`/`body_site.py`/`host_species.py`.
+2. **Round-trip** — `app.normalization.ols.fetch_term()` re-fetches the
+   `ontology_id` directly from OLS by IRI and confirms it still resolves to
+   something. A miss here is the strongest signal of a fabricated or
+   since-deleted ID.
+3. **Branch check** — `app.normalization.ols.is_in_branch()` confirms the
+   term is still reachable from its ontology's declared root
+   (`grounding.py`'s `ROOTS`: EFO→`EFO:0000408` "disease",
+   MONDO→`MONDO:0000001` "disease or disorder",
+   UBERON→`UBERON:0001062` "anatomical entity",
+   NCBITaxon→`NCBITaxon:2759` "Eukaryota"). Catches a static ID that now
+   resolves to an unrelated concept even though the ID itself still exists —
+   exactly the "COVID-19 pointing at an obsolete anatomy term" failure mode
+   from the original incident, but caught automatically instead of by a
+   human spot-check.
+4. **Obsolete check** — `fetch_term()` also surfaces OLS's own `is_obsolete`
+   flag and `term_replaced_by`, so a deprecated-but-still-resolving term
+   doesn't slip through as `"auto"` either.
+
+**Scope, deliberately narrow:** this only ever downgrades `auto → review`,
+never the reverse, and never touches live-OLS-lookup results (those were
+already `"review"` per the existing source-based tiering and stay there —
+loosening that to a match-quality-based tiering, the way metacurator itself
+does it, would reopen the hole this whole system exists to close).
+
+**Cost:** the static dicts contain on the order of 50 unique `ontology_id`s
+total across all three modules. Results are cached
+(`grounding_check_cache`, SQLite, TTL-based via `GROUNDING_CACHE_VALIDITY_HOURS`
+— unlike `ontology_term_cache`, this cache is *meant* to expire, since
+obsolescence is exactly the drift it exists to catch) — so this is one OLS
+round-trip per unique ID per TTL window, not per request.
+
+**Failure mode if OLS is unreachable:** treated as "unable to verify," and
+the match keeps whatever tier it already had (fail open) rather than forcing
+every result to `"review"` during an OLS outage.
+
+**Not implemented — a local ontology store:** metacurator also supports a
+DuckDB/semantic-sql-derived local ontology backend as a faster, offline
+alternative to live OLS. Given this codebase's static dicts only need to
+verify ~50 IDs (not run arbitrary free-text search against a full ontology),
+the cost/benefit didn't justify a new heavy dependency and a multi-GB
+ontology-dump ETL/refresh pipeline for this pass — flagged as a future
+option if OLS latency/availability becomes an actual problem, not built
+ahead of that need (same reasoning as "Scope decision" above).
+
+**Caveat:** the exact OLS4 JSON field names used here (`is_obsolete`,
+`term_replaced_by`, `_embedded.terms`) are based on OLS's documented/
+historically-stable REST API rather than a live call made during this
+change (this session's network access to `ebi.ac.uk` was blocked). Every
+parse path degrades to "unable to verify" rather than raising on an
+unexpected shape, but this should get a real smoke-test against live OLS
+before anyone relies on the round-trip/branch/obsolete checks actually
+firing correctly in production.

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -1,5 +1,38 @@
+import pytest
+
+from app.normalization import grounding as grounding_module
+from app.normalization import ols as ols_module
 from app.normalization.grounding import TIER_AUTO, TIER_NONE, TIER_REVIEW, tier_for
+from app.normalization.ols import TermVerification
 from app.normalization.types import NormalizedTerm
+
+
+@pytest.fixture(autouse=True)
+def _no_grounding_cache(monkeypatch):
+    """Grounding checks persist to a real on-disk SQLite cache
+    (grounding_check_cache); disable that here so each test's fetch_term/
+    is_in_branch mock is actually exercised instead of being short-circuited
+    by a previous test's cached result for the same ontology_id."""
+    monkeypatch.setattr(grounding_module, "get_cached_grounding", lambda *a: None)
+    monkeypatch.setattr(
+        grounding_module, "store_cached_grounding", lambda *a, **k: None
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_live_ols(monkeypatch):
+    """By default, make the round-trip/branch checks behave as if OLS
+    confirmed the term is live, not obsolete, and in-branch — i.e. a static
+    match that grounds cleanly. Individual tests override fetch_term/
+    is_in_branch to exercise the downgrade paths instead. Without this,
+    tier_for() would attempt a real network call to OLS on every "auto"-
+    candidate test, which is exactly what CLAUDE.md says this suite avoids."""
+
+    def _fake_fetch_term(ontology_id, default_prefix=""):
+        return TermVerification(exists=True, label="stub label", is_obsolete=False)
+
+    monkeypatch.setattr(ols_module, "fetch_term", _fake_fetch_term)
+    monkeypatch.setattr(ols_module, "is_in_branch", lambda *a: True)
 
 
 def test_tier_none_when_no_ontology_id():
@@ -40,3 +73,104 @@ def test_tier_review_for_live_lookup_match():
         mapping_confidence=0.9,
     )
     assert tier_for(term) == TIER_REVIEW
+
+
+# ---------------------------------------------------------------------------
+# Four-step grounding discipline: round-trip / obsolete / branch downgrades
+# ---------------------------------------------------------------------------
+
+
+def _static_match(ontology_id: str) -> NormalizedTerm:
+    return NormalizedTerm(
+        label="Parkinson disease",
+        ontology_id=ontology_id,
+        status="PRESENT",
+        mapping_confidence=1.0,
+    )
+
+
+def test_tier_auto_when_static_match_grounds_cleanly():
+    # Sanity check that the default fixture stubs actually let "auto" through.
+    assert tier_for(_static_match("MONDO:0005180")) == TIER_AUTO
+
+
+def test_tier_downgraded_when_round_trip_fails(monkeypatch):
+    """The ID doesn't resolve to anything on OLS anymore - the strongest
+    possible signal of a fabricated/deleted static entry."""
+    monkeypatch.setattr(
+        ols_module, "fetch_term", lambda *a, **k: TermVerification(exists=False)
+    )
+    assert tier_for(_static_match("MONDO:0005180")) == TIER_REVIEW
+
+
+def test_tier_downgraded_when_term_is_obsolete(monkeypatch):
+    monkeypatch.setattr(
+        ols_module,
+        "fetch_term",
+        lambda *a, **k: TermVerification(
+            exists=True,
+            label="obsolete_Parkinson's disease",
+            is_obsolete=True,
+            replaced_by="MONDO:0005180",
+        ),
+    )
+    assert tier_for(_static_match("EFO:0002508")) == TIER_REVIEW
+
+
+def test_tier_downgraded_when_branch_check_fails(monkeypatch):
+    """Term round-trips and isn't obsolete, but no longer lives under its
+    ontology's declared root - it now resolves to an unrelated concept."""
+    monkeypatch.setattr(
+        ols_module,
+        "fetch_term",
+        lambda *a, **k: TermVerification(exists=True, label="somite 13"),
+    )
+    monkeypatch.setattr(ols_module, "is_in_branch", lambda *a: False)
+    assert tier_for(_static_match("EFO:0003601")) == TIER_REVIEW
+
+
+def test_tier_stays_auto_when_ols_unreachable(monkeypatch):
+    """OLS being unreachable is treated as "unable to verify", not "failed" -
+    the match keeps its prior tier (fail open) rather than forcing every
+    result to "review" during an OLS outage."""
+    monkeypatch.setattr(ols_module, "fetch_term", lambda *a, **k: None)
+    assert tier_for(_static_match("MONDO:0005180")) == TIER_AUTO
+
+
+def test_tier_auto_for_unmapped_ontology_prefix():
+    """A prefix with no configured branch root (e.g. BugSigDB's own
+    controlled vocab, which never has an ontology_id, or a future ontology
+    not yet wired into ROOTS) skips grounding entirely rather than erroring."""
+    term = NormalizedTerm(
+        label="widget",
+        ontology_id="UNKNOWNONTOLOGY:123",
+        status="PRESENT",
+        mapping_confidence=1.0,
+    )
+    assert tier_for(term) == TIER_AUTO
+
+
+def test_grounding_result_is_cached(monkeypatch):
+    calls = []
+
+    def _fake_fetch_term(ontology_id, default_prefix=""):
+        calls.append(ontology_id)
+        return TermVerification(exists=True, label="Parkinson disease")
+
+    store = {}
+    monkeypatch.setattr(ols_module, "fetch_term", _fake_fetch_term)
+    monkeypatch.setattr(
+        grounding_module,
+        "store_cached_grounding",
+        lambda ontology_id, **kw: store.__setitem__(ontology_id, kw),
+    )
+    monkeypatch.setattr(
+        grounding_module,
+        "get_cached_grounding",
+        lambda ontology_id: store.get(ontology_id),
+    )
+
+    term = _static_match("MONDO:0005180")
+    assert tier_for(term) == TIER_AUTO
+    assert tier_for(term) == TIER_AUTO
+    assert calls == ["MONDO:0005180"]  # second call served from the cache

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -9,16 +9,11 @@ from app.normalization import host_species as host_species_module
 from app.normalization import ols as ols_module
 from app.normalization import sample_size as sample_size_module
 from app.normalization.body_site import normalize_body_site
-from app.normalization.condition import (
-    normalize_condition,
-    _extract_clean_disease_name,
-    _progressive_queries,
-)
+from app.normalization.condition import normalize_condition, _extract_clean_disease_name
 from app.normalization.host_species import normalize_host_species
 from app.normalization.ols import format_ontology_id, ols_search
 from app.normalization.sample_size import normalize_sample_size, _simple_word_to_num
 from app.normalization.sequencing_type import normalize_sequencing_type
-from app.normalization.types import normalize_spelling
 
 
 @pytest.fixture(autouse=True)
@@ -357,16 +352,14 @@ def test_host_species_ncbi_fallback_handles_narrowed_exceptions(monkeypatch, fak
 
 def test_ols_search_success(monkeypatch):
     def fake_get(url, params=None, timeout=None):
-        if url == ols_module.OLS_SEARCH_URL:
-            return _DummyResponse(
-                {
-                    "response": {
-                        "docs": [{"label": "felis catus", "obo_id": "NCBITaxon_9685"}]
-                    }
+        assert url == ols_module.OLS_SEARCH_URL
+        return _DummyResponse(
+            {
+                "response": {
+                    "docs": [{"label": "felis catus", "obo_id": "NCBITaxon_9685"}]
                 }
-            )
-        assert url == ols_module.OLS_TERMS_URL
-        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": False}]}})
+            }
+        )
 
     monkeypatch.setattr(requests, "get", fake_get)
     result = ols_search("domestic cat", "ncbitaxon", "NCBITaxon")
@@ -396,154 +389,140 @@ def test_ols_search_handles_malformed_json(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# ols.py: round-trip obsolete-check (adopted from metacurator's no-
-# hallucination discipline - see docs/METACURATOR_METAHARMONIZER_ANALYSIS.md)
+# ols.py: fetch_term() / is_in_branch() - the round-trip, obsolete-detection,
+# and branch-check steps of the four-step grounding discipline consumed by
+# app.normalization.grounding. See that module's docstring for how these
+# combine to gate the "auto" mapping tier.
 # ---------------------------------------------------------------------------
 
 
-def test_ols_search_rejects_obsolete_term(monkeypatch):
-    """A search hit alone isn't proof a term is current - if the round-trip
-    lookup confirms it's obsolete, ols_search must reject it rather than
-    return/cache a dead ID."""
+def test_obo_iri_builds_purl_from_curie():
+    assert (
+        ols_module._obo_iri("EFO:0000400")
+        == "http://purl.obolibrary.org/obo/EFO_0000400"
+    )
+    assert ols_module._obo_iri("NCBITaxon:9606") == (
+        "http://purl.obolibrary.org/obo/NCBITaxon_9606"
+    )
 
+
+def test_obo_iri_returns_none_for_malformed_id():
+    assert ols_module._obo_iri("not-a-curie") is None
+    assert ols_module._obo_iri("") is None
+
+
+def test_fetch_term_round_trip_success(monkeypatch):
     def fake_get(url, params=None, timeout=None):
-        if url == ols_module.OLS_SEARCH_URL:
-            return _DummyResponse(
-                {"response": {"docs": [{"label": "old term", "obo_id": "EFO_0001111"}]}}
-            )
         assert url == ols_module.OLS_TERMS_URL
-        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": True}]}})
-
-    monkeypatch.setattr(requests, "get", fake_get)
-    assert ols_search("some term", "efo", "EFO") is None
-
-
-def test_ols_search_fails_open_when_round_trip_lookup_errors(monkeypatch):
-    """A transient failure on the round-trip call (network error) must not
-    reject an otherwise-good search hit - only a confirmed obsolete flag
-    should reject."""
-
-    def fake_get(url, params=None, timeout=None):
-        if url == ols_module.OLS_SEARCH_URL:
-            return _DummyResponse(
-                {
-                    "response": {
-                        "docs": [{"label": "some term", "obo_id": "EFO_0002222"}]
-                    }
-                }
-            )
-        raise requests.exceptions.Timeout("round-trip timed out")
-
-    monkeypatch.setattr(requests, "get", fake_get)
-    result = ols_search("some term", "efo", "EFO")
-    assert result == ("some term", "EFO:0002222", 0.9)
-
-
-def test_ols_search_accepts_when_round_trip_finds_no_embedded_terms(monkeypatch):
-    """An inconclusive round-trip (no terms in the response) fails open,
-    same as a network error - only a positive obsolete confirmation rejects."""
-
-    def fake_get(url, params=None, timeout=None):
-        if url == ols_module.OLS_SEARCH_URL:
-            return _DummyResponse(
-                {
-                    "response": {
-                        "docs": [{"label": "some term", "obo_id": "EFO_0003333"}]
-                    }
-                }
-            )
-        return _DummyResponse({"_embedded": {"terms": []}})
-
-    monkeypatch.setattr(requests, "get", fake_get)
-    result = ols_search("some term", "efo", "EFO")
-    assert result == ("some term", "EFO:0003333", 0.9)
-
-
-# ---------------------------------------------------------------------------
-# types.py: normalize_spelling (British -> American, ported from
-# MetaHarmonizer after our benchmark found the "faecal" vs "feces" gap)
-# ---------------------------------------------------------------------------
-
-
-def test_normalize_spelling_body_site_terms():
-    # Every real call site applies this to already-lowercased text; the
-    # replacement itself is always lowercase (case-preservation isn't a
-    # requirement this codebase's usage pattern needs).
-    assert normalize_spelling("faecal samples") == "fecal samples"
-    assert normalize_spelling("faeces collected") == "feces collected"
-
-
-def test_normalize_spelling_condition_terms():
-    assert normalize_spelling("diarrhoea and anaemia") == "diarrhea and anemia"
-    assert normalize_spelling("paediatric leukaemia") == "pediatric leukemia"
-
-
-def test_normalize_spelling_passthrough_for_american_text():
-    assert normalize_spelling("fecal samples, no changes needed") == (
-        "fecal samples, no changes needed"
-    )
-
-
-def test_body_site_matches_british_spelling_via_static_lookup():
-    t = normalize_body_site("faecal samples were collected")
-    assert t.label == "feces"
-    assert t.ontology_id == "UBERON:0001988"
-    assert t.status == "PRESENT"
-
-
-# ---------------------------------------------------------------------------
-# condition.py: _progressive_queries (modifier-phrase gap found via a live
-# cross-check against metacurator's real MONDO grounding)
-# ---------------------------------------------------------------------------
-
-
-def test_progressive_queries_strips_leading_modifier():
-    queries = list(
-        _progressive_queries("diarrhea-predominant irritable bowel syndrome")
-    )
-    assert queries[0] == "diarrhea-predominant irritable bowel syndrome"
-    assert "irritable bowel syndrome" in queries
-
-
-def test_progressive_queries_caps_extra_attempts():
-    queries = list(_progressive_queries("a b c d e f", max_extra=2))
-    assert len(queries) == 3  # original + 2 extra, not one per word
-
-
-def test_progressive_queries_stops_at_two_words():
-    queries = list(_progressive_queries("a b", max_extra=5))
-    assert queries == ["a b"]
-
-
-def test_condition_live_fallback_finds_modifier_stripped_match(monkeypatch):
-    """Regression test for the exact gap found via a live cross-check
-    against metacurator: a clinical modifier prefix can make the full
-    extracted phrase miss a live OLS/MONDO search that the bare condition
-    name would have matched."""
-
-    def fake_get(url, params=None, timeout=None):
-        if url == ols_module.OLS_SEARCH_URL:
-            if params and params.get("q") == "irritable bowel syndrome":
-                return _DummyResponse(
-                    {
-                        "response": {
-                            "docs": [
-                                {
-                                    "label": "irritable bowel syndrome",
-                                    "obo_id": "MONDO_0005052",
-                                }
-                            ]
+        assert params == {"iri": "http://purl.obolibrary.org/obo/MONDO_0005180"}
+        return _DummyResponse(
+            {
+                "_embedded": {
+                    "terms": [
+                        {
+                            "label": "Parkinson disease",
+                            "obo_id": "MONDO:0005180",
+                            "is_obsolete": False,
                         }
-                    }
-                )
-            return _DummyResponse({"response": {"docs": []}})
-        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": False}]}})
+                    ]
+                }
+            }
+        )
 
     monkeypatch.setattr(requests, "get", fake_get)
-    t = normalize_condition("diarrhea-predominant irritable bowel syndrome")
-    assert t.label == "irritable bowel syndrome"
-    assert t.ontology_id == "MONDO:0005052"
-    assert t.status == "PRESENT"
+    result = ols_module.fetch_term("MONDO:0005180")
+    assert result.exists is True
+    assert result.label == "Parkinson disease"
+    assert result.is_obsolete is False
+    assert result.replaced_by == ""
+
+
+def test_fetch_term_reports_missing_term(monkeypatch):
+    """The strongest possible signal of a fabricated/deleted static
+    entry - the IRI resolves to nothing at all."""
+    monkeypatch.setattr(
+        requests, "get", lambda *a, **k: _DummyResponse({"_embedded": {"terms": []}})
+    )
+    result = ols_module.fetch_term("EFO:0003601")
+    assert result.exists is False
+
+
+def test_fetch_term_reports_obsolete_with_replacement(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda *a, **k: _DummyResponse(
+            {
+                "_embedded": {
+                    "terms": [
+                        {
+                            "label": "obsolete_Parkinson's disease",
+                            "obo_id": "EFO:0002508",
+                            "is_obsolete": True,
+                            "term_replaced_by": "MONDO_0005180",
+                        }
+                    ]
+                }
+            }
+        ),
+    )
+    result = ols_module.fetch_term("EFO:0002508")
+    assert result.exists is True
+    assert result.is_obsolete is True
+    assert result.replaced_by == "MONDO:0005180"
+
+
+def test_fetch_term_handles_request_exception(monkeypatch):
+    def fake_get(*a, **k):
+        raise requests.exceptions.Timeout("timed out")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert ols_module.fetch_term("MONDO:0005180") is None
+
+
+def test_fetch_term_returns_none_for_malformed_id():
+    assert ols_module.fetch_term("not-a-curie") is None
+
+
+def test_is_in_branch_true_when_root_in_ancestors(monkeypatch):
+    def fake_get(url, timeout=None):
+        return _DummyResponse(
+            {"_embedded": {"terms": [{"label": "disease", "obo_id": "MONDO:0000001"}]}}
+        )
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert ols_module.is_in_branch("MONDO:0005180", "mondo", "MONDO:0000001") is True
+
+
+def test_is_in_branch_false_when_root_missing(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda *a, **k: _DummyResponse(
+            {"_embedded": {"terms": [{"label": "somite", "obo_id": "UBERON:0002329"}]}}
+        ),
+    )
+    assert ols_module.is_in_branch("EFO:0003601", "efo", "EFO:0000408") is False
+
+
+def test_is_in_branch_true_when_term_is_the_root():
+    # Short-circuits before any network call.
+    assert ols_module.is_in_branch("MONDO:0000001", "mondo", "MONDO:0000001") is True
+
+
+def test_is_in_branch_returns_none_on_request_exception(monkeypatch):
+    def fake_get(*a, **k):
+        raise requests.exceptions.Timeout("timed out")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert ols_module.is_in_branch("MONDO:0005180", "mondo", "MONDO:0000001") is None
+
+
+def test_is_in_branch_returns_false_on_404(monkeypatch):
+    monkeypatch.setattr(
+        requests, "get", lambda *a, **k: _DummyResponse(status_code=404)
+    )
+    assert ols_module.is_in_branch("MONDO:0005180", "mondo", "MONDO:0000001") is False
 
 
 # ---------------------------------------------------------------------------
@@ -592,16 +571,10 @@ def test_host_species_multiple_matches_surfaces_candidates():
 
 def test_body_site_ols_fallback_success(monkeypatch):
     def fake_get(url, params=None, timeout=None):
-        if url == ols_module.OLS_SEARCH_URL:
-            return _DummyResponse(
-                {
-                    "response": {
-                        "docs": [{"label": "duodenum", "obo_id": "UBERON_0002114"}]
-                    }
-                }
-            )
-        assert url == ols_module.OLS_TERMS_URL
-        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": False}]}})
+        assert url == ols_module.OLS_SEARCH_URL
+        return _DummyResponse(
+            {"response": {"docs": [{"label": "duodenum", "obo_id": "UBERON_0002114"}]}}
+        )
 
     monkeypatch.setattr(requests, "get", fake_get)
     t = normalize_body_site("duodenal biopsy")
@@ -645,18 +618,14 @@ def test_extract_clean_disease_name_passes_through_when_no_phrase_matches():
 
 def test_condition_ols_fallback_success(monkeypatch):
     def fake_get(url, params=None, timeout=None):
-        if url == ols_module.OLS_SEARCH_URL:
-            return _DummyResponse(
-                {
-                    "response": {
-                        "docs": [
-                            {"label": "rare metabolic disorder", "obo_id": "EFO_9999"}
-                        ]
-                    }
+        assert url == ols_module.OLS_SEARCH_URL
+        return _DummyResponse(
+            {
+                "response": {
+                    "docs": [{"label": "rare metabolic disorder", "obo_id": "EFO_9999"}]
                 }
-            )
-        assert url == ols_module.OLS_TERMS_URL
-        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": False}]}})
+            }
+        )
 
     monkeypatch.setattr(requests, "get", fake_get)
     t = normalize_condition("patients with a rare metabolic disorder")

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -9,11 +9,16 @@ from app.normalization import host_species as host_species_module
 from app.normalization import ols as ols_module
 from app.normalization import sample_size as sample_size_module
 from app.normalization.body_site import normalize_body_site
-from app.normalization.condition import normalize_condition, _extract_clean_disease_name
+from app.normalization.condition import (
+    normalize_condition,
+    _extract_clean_disease_name,
+    _progressive_queries,
+)
 from app.normalization.host_species import normalize_host_species
 from app.normalization.ols import format_ontology_id, ols_search
 from app.normalization.sample_size import normalize_sample_size, _simple_word_to_num
 from app.normalization.sequencing_type import normalize_sequencing_type
+from app.normalization.types import normalize_spelling
 
 
 @pytest.fixture(autouse=True)
@@ -352,14 +357,16 @@ def test_host_species_ncbi_fallback_handles_narrowed_exceptions(monkeypatch, fak
 
 def test_ols_search_success(monkeypatch):
     def fake_get(url, params=None, timeout=None):
-        assert url == ols_module.OLS_SEARCH_URL
-        return _DummyResponse(
-            {
-                "response": {
-                    "docs": [{"label": "felis catus", "obo_id": "NCBITaxon_9685"}]
+        if url == ols_module.OLS_SEARCH_URL:
+            return _DummyResponse(
+                {
+                    "response": {
+                        "docs": [{"label": "felis catus", "obo_id": "NCBITaxon_9685"}]
+                    }
                 }
-            }
-        )
+            )
+        assert url == ols_module.OLS_TERMS_URL
+        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": False}]}})
 
     monkeypatch.setattr(requests, "get", fake_get)
     result = ols_search("domestic cat", "ncbitaxon", "NCBITaxon")
@@ -386,6 +393,157 @@ def test_ols_search_handles_malformed_json(monkeypatch):
         requests, "get", lambda *a, **k: _DummyResponse(raise_json_error=True)
     )
     assert ols_search("some term", "efo", "EFO") is None
+
+
+# ---------------------------------------------------------------------------
+# ols.py: round-trip obsolete-check (adopted from metacurator's no-
+# hallucination discipline - see docs/METACURATOR_METAHARMONIZER_ANALYSIS.md)
+# ---------------------------------------------------------------------------
+
+
+def test_ols_search_rejects_obsolete_term(monkeypatch):
+    """A search hit alone isn't proof a term is current - if the round-trip
+    lookup confirms it's obsolete, ols_search must reject it rather than
+    return/cache a dead ID."""
+
+    def fake_get(url, params=None, timeout=None):
+        if url == ols_module.OLS_SEARCH_URL:
+            return _DummyResponse(
+                {"response": {"docs": [{"label": "old term", "obo_id": "EFO_0001111"}]}}
+            )
+        assert url == ols_module.OLS_TERMS_URL
+        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": True}]}})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert ols_search("some term", "efo", "EFO") is None
+
+
+def test_ols_search_fails_open_when_round_trip_lookup_errors(monkeypatch):
+    """A transient failure on the round-trip call (network error) must not
+    reject an otherwise-good search hit - only a confirmed obsolete flag
+    should reject."""
+
+    def fake_get(url, params=None, timeout=None):
+        if url == ols_module.OLS_SEARCH_URL:
+            return _DummyResponse(
+                {
+                    "response": {
+                        "docs": [{"label": "some term", "obo_id": "EFO_0002222"}]
+                    }
+                }
+            )
+        raise requests.exceptions.Timeout("round-trip timed out")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    result = ols_search("some term", "efo", "EFO")
+    assert result == ("some term", "EFO:0002222", 0.9)
+
+
+def test_ols_search_accepts_when_round_trip_finds_no_embedded_terms(monkeypatch):
+    """An inconclusive round-trip (no terms in the response) fails open,
+    same as a network error - only a positive obsolete confirmation rejects."""
+
+    def fake_get(url, params=None, timeout=None):
+        if url == ols_module.OLS_SEARCH_URL:
+            return _DummyResponse(
+                {
+                    "response": {
+                        "docs": [{"label": "some term", "obo_id": "EFO_0003333"}]
+                    }
+                }
+            )
+        return _DummyResponse({"_embedded": {"terms": []}})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    result = ols_search("some term", "efo", "EFO")
+    assert result == ("some term", "EFO:0003333", 0.9)
+
+
+# ---------------------------------------------------------------------------
+# types.py: normalize_spelling (British -> American, ported from
+# MetaHarmonizer after our benchmark found the "faecal" vs "feces" gap)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_spelling_body_site_terms():
+    # Every real call site applies this to already-lowercased text; the
+    # replacement itself is always lowercase (case-preservation isn't a
+    # requirement this codebase's usage pattern needs).
+    assert normalize_spelling("faecal samples") == "fecal samples"
+    assert normalize_spelling("faeces collected") == "feces collected"
+
+
+def test_normalize_spelling_condition_terms():
+    assert normalize_spelling("diarrhoea and anaemia") == "diarrhea and anemia"
+    assert normalize_spelling("paediatric leukaemia") == "pediatric leukemia"
+
+
+def test_normalize_spelling_passthrough_for_american_text():
+    assert normalize_spelling("fecal samples, no changes needed") == (
+        "fecal samples, no changes needed"
+    )
+
+
+def test_body_site_matches_british_spelling_via_static_lookup():
+    t = normalize_body_site("faecal samples were collected")
+    assert t.label == "feces"
+    assert t.ontology_id == "UBERON:0001988"
+    assert t.status == "PRESENT"
+
+
+# ---------------------------------------------------------------------------
+# condition.py: _progressive_queries (modifier-phrase gap found via a live
+# cross-check against metacurator's real MONDO grounding)
+# ---------------------------------------------------------------------------
+
+
+def test_progressive_queries_strips_leading_modifier():
+    queries = list(
+        _progressive_queries("diarrhea-predominant irritable bowel syndrome")
+    )
+    assert queries[0] == "diarrhea-predominant irritable bowel syndrome"
+    assert "irritable bowel syndrome" in queries
+
+
+def test_progressive_queries_caps_extra_attempts():
+    queries = list(_progressive_queries("a b c d e f", max_extra=2))
+    assert len(queries) == 3  # original + 2 extra, not one per word
+
+
+def test_progressive_queries_stops_at_two_words():
+    queries = list(_progressive_queries("a b", max_extra=5))
+    assert queries == ["a b"]
+
+
+def test_condition_live_fallback_finds_modifier_stripped_match(monkeypatch):
+    """Regression test for the exact gap found via a live cross-check
+    against metacurator: a clinical modifier prefix can make the full
+    extracted phrase miss a live OLS/MONDO search that the bare condition
+    name would have matched."""
+
+    def fake_get(url, params=None, timeout=None):
+        if url == ols_module.OLS_SEARCH_URL:
+            if params and params.get("q") == "irritable bowel syndrome":
+                return _DummyResponse(
+                    {
+                        "response": {
+                            "docs": [
+                                {
+                                    "label": "irritable bowel syndrome",
+                                    "obo_id": "MONDO_0005052",
+                                }
+                            ]
+                        }
+                    }
+                )
+            return _DummyResponse({"response": {"docs": []}})
+        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": False}]}})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    t = normalize_condition("diarrhea-predominant irritable bowel syndrome")
+    assert t.label == "irritable bowel syndrome"
+    assert t.ontology_id == "MONDO:0005052"
+    assert t.status == "PRESENT"
 
 
 # ---------------------------------------------------------------------------
@@ -434,10 +592,16 @@ def test_host_species_multiple_matches_surfaces_candidates():
 
 def test_body_site_ols_fallback_success(monkeypatch):
     def fake_get(url, params=None, timeout=None):
-        assert url == ols_module.OLS_SEARCH_URL
-        return _DummyResponse(
-            {"response": {"docs": [{"label": "duodenum", "obo_id": "UBERON_0002114"}]}}
-        )
+        if url == ols_module.OLS_SEARCH_URL:
+            return _DummyResponse(
+                {
+                    "response": {
+                        "docs": [{"label": "duodenum", "obo_id": "UBERON_0002114"}]
+                    }
+                }
+            )
+        assert url == ols_module.OLS_TERMS_URL
+        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": False}]}})
 
     monkeypatch.setattr(requests, "get", fake_get)
     t = normalize_body_site("duodenal biopsy")
@@ -481,14 +645,18 @@ def test_extract_clean_disease_name_passes_through_when_no_phrase_matches():
 
 def test_condition_ols_fallback_success(monkeypatch):
     def fake_get(url, params=None, timeout=None):
-        assert url == ols_module.OLS_SEARCH_URL
-        return _DummyResponse(
-            {
-                "response": {
-                    "docs": [{"label": "rare metabolic disorder", "obo_id": "EFO_9999"}]
+        if url == ols_module.OLS_SEARCH_URL:
+            return _DummyResponse(
+                {
+                    "response": {
+                        "docs": [
+                            {"label": "rare metabolic disorder", "obo_id": "EFO_9999"}
+                        ]
+                    }
                 }
-            }
-        )
+            )
+        assert url == ols_module.OLS_TERMS_URL
+        return _DummyResponse({"_embedded": {"terms": [{"is_obsolete": False}]}})
 
     monkeypatch.setattr(requests, "get", fake_get)
     t = normalize_condition("patients with a rare metabolic disorder")

--- a/tests/test_ontology_lookup_caching.py
+++ b/tests/test_ontology_lookup_caching.py
@@ -17,13 +17,6 @@ def _fake_ols_response(label: str, obo_id: str):
     return resp
 
 
-def _fake_ols_terms_response(is_obsolete: bool = False):
-    resp = MagicMock()
-    resp.raise_for_status = MagicMock()
-    resp.json.return_value = {"_embedded": {"terms": [{"is_obsolete": is_obsolete}]}}
-    return resp
-
-
 class TestOlsSearchCaching:
     def test_cache_hit_skips_network_call(self, monkeypatch):
         monkeypatch.setattr(
@@ -47,13 +40,12 @@ class TestOlsSearchCaching:
         monkeypatch.setattr(ols, "store_cached_term", store_mock)
 
         with patch("app.normalization.ols.requests.get") as mock_get:
-            mock_get.side_effect = [
-                _fake_ols_response("Parkinson disease", "EFO_0002508"),
-                _fake_ols_terms_response(is_obsolete=False),
-            ]
+            mock_get.return_value = _fake_ols_response(
+                "Parkinson disease", "EFO_0002508"
+            )
             result = ols.ols_search("parkinsons", "efo", "EFO", mapping_confidence=0.9)
 
-        assert mock_get.call_count == 2
+        mock_get.assert_called_once()
         store_mock.assert_called_once_with(
             "efo", "parkinsons", "Parkinson disease", "EFO:0002508", 0.9
         )

--- a/tests/test_ontology_lookup_caching.py
+++ b/tests/test_ontology_lookup_caching.py
@@ -17,6 +17,13 @@ def _fake_ols_response(label: str, obo_id: str):
     return resp
 
 
+def _fake_ols_terms_response(is_obsolete: bool = False):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"_embedded": {"terms": [{"is_obsolete": is_obsolete}]}}
+    return resp
+
+
 class TestOlsSearchCaching:
     def test_cache_hit_skips_network_call(self, monkeypatch):
         monkeypatch.setattr(
@@ -40,12 +47,13 @@ class TestOlsSearchCaching:
         monkeypatch.setattr(ols, "store_cached_term", store_mock)
 
         with patch("app.normalization.ols.requests.get") as mock_get:
-            mock_get.return_value = _fake_ols_response(
-                "Parkinson disease", "EFO_0002508"
-            )
+            mock_get.side_effect = [
+                _fake_ols_response("Parkinson disease", "EFO_0002508"),
+                _fake_ols_terms_response(is_obsolete=False),
+            ]
             result = ols.ols_search("parkinsons", "efo", "EFO", mapping_confidence=0.9)
 
-        mock_get.assert_called_once()
+        assert mock_get.call_count == 2
         store_mock.assert_called_once_with(
             "efo", "parkinsons", "Parkinson disease", "EFO:0002508", 0.9
         )


### PR DESCRIPTION
Ports [metacurator](https://github.com/seandavi/metacurator)'s four-step grounding discipline (lookup → round-trip → branch check → obsolete check) into [app/normalization/grounding.py](https://github.com/waldronlab/bioanalyzer-backend/blob/main/app/normalization/grounding.py) as a downgrade-only safety gate on the mapping_tier field, so a static ontology-ID lookup can't silently keep shipping at "auto" confidence after the ontology itself deprecates or deletes that ID.

Background
The 2026-07-11/12 audit found 26/27 hardcoded EFO IDs in condition.py were wrong or obsolete, and fixed them via a one-time manual re-verification against live OLS. That fixed the symptom, not the cause: nothing re-checks a static match after the fact, so if EFO deprecates a currently-correct ID next year, tier_for() would keep returning "auto" for it indefinitely — the same failure mode, just latent instead of active.

This PR closes that gap by making the grounding check continuous instead of one-time.

What changed
[app/normalization/ols.py](https://github.com/waldronlab/bioanalyzer-backend/blob/main/app/normalization/ols.py) — added fetch_term() (round-trip: re-fetches an ontology_id from OLS by IRI, confirms it exists, surfaces is_obsolete/replaced_by) and is_in_branch() (branch check: confirms the term is still reachable from its ontology's declared root via hierarchicalAncestors).
[app/normalization/grounding.py](https://github.com/waldronlab/bioanalyzer-backend/blob/main/app/normalization/grounding.py) — tier_for() now runs these checks against any match that would otherwise earn "auto", downgrading to "review" if any step fails. Declares per-ontology branch roots (EFO:0000408 "disease", MONDO:0000001 "disease or disorder", UBERON:0001062 "anatomical entity", NCBITaxon:2759 "Eukaryota").
[app/services/cache_manager.py](https://github.com/waldronlab/bioanalyzer-backend/blob/main/app/services/cache_manager.py) / [app/normalization/ontology_cache.py](https://github.com/waldronlab/bioanalyzer-backend/blob/main/app/normalization/ontology_cache.py) — new grounding_check_cache table (TTL-based via GROUNDING_CACHE_VALIDITY_HOURS, default 30 days) so this is one OLS round-trip per unique static ID per TTL window, not per request — the static dicts only cover ~50 unique IDs total.
[app/services/agent_orchestrator.py](https://github.com/waldronlab/bioanalyzer-backend/blob/main/app/services/agent_orchestrator.py) — found during audit: _extract_experiments (async) called the normalizer-parsing path directly, unlike its sibling call sites in simple_analysis.py/rag_analysis.py, which already offload to asyncio.to_thread because normalization can make blocking network calls. Since this PR adds more of that blocking I/O, applied the same fix here to avoid stalling the event loop.
[app/models/extraction_schemas.py](https://github.com/waldronlab/bioanalyzer-backend/blob/main/app/models/extraction_schemas.py), .env.example, [docs/ONTOLOGY_AUDIT.md](https://github.com/waldronlab/bioanalyzer-backend/blob/main/docs/ONTOLOGY_AUDIT.md) — updated docs/config for the new tier semantics and env var.
Tests — 24 new tests across [tests/test_grounding.py](https://github.com/waldronlab/bioanalyzer-backend/blob/main/tests/test_grounding.py) and [tests/test_normalization.py](https://github.com/waldronlab/bioanalyzer-backend/blob/main/tests/test_normalization.py) covering round-trip failure, obsolete detection, branch-check failure, cache behavior, and the OLS-unreachable fail-open path. All fully mocked, no live network dependency.
Design constraints (deliberate)
Downgrade-only, source-based tiering preserved. This never promotes a live-OLS/NCBI lookup to "auto" — those stay "review" exactly as before. Loosening that would reopen the original hole; this PR only re-verifies that a static match can still be trusted.
No API/CSV contract changes. tier_for(term)'s signature is unchanged and untouched at all 3 call sites — the ontology prefix on ontology_id (EFO:/MONDO:/UBERON:/NCBITaxon:) is enough to derive which OLS ontology/root to check. FieldResult's fields, types, and defaults are unchanged (only the mapping_tier description text was clarified).
Fails open on OLS outage — an unreachable OLS keeps a match's prior tier rather than forcing every result to "review".
Testing
pytest tests/test_grounding.py tests/test_normalization.py tests/test_cache_manager.py — all passing (120 tests)
Full locally-collectible suite — 283 passed, 62 skipped; remaining failures are pre-existing missing-dependency issues in this sandbox (litellm not installed), unrelated to this change
black, flake8, bandit -ll — clean on all changed files