### PR TITLE
Repoint semantic-sql base URL to the CDN endpoint

### DIFF
--- a/app/normalization/grounding/seed.py
+++ b/app/normalization/grounding/seed.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 # pass via a direct HEAD request
 # (HTTP 200, `Content-Type: application/gzip`) for every ontology slug in
 # ROOTS/EXTENDED_ONTOLOGY_ROOTS.
-SEMANTIC_SQL_BASE_URL = "https://s3.amazonaws.com/bbop-sqlite"
+SEMANTIC_SQL_BASE_URL = "https://semanticsql.berkeleybop.io"
 
 # prefix -> the ontology's static lookup dict, keyed by the same prefixes
 # app.normalization.grounding.roots.ROOTS declares. Ontologies with no


### PR DESCRIPTION
The raw bbop-sqlite S3 bucket is being retired; same paths work at the CDN (INCATools/semantic-sql#115).

Closes #124